### PR TITLE
SetupShop: A Supplemental `setup.py`/`setuptools.setup` Utility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setupshop = SetupShop(
 
 setup(
     name=setupshop.name,
-    version=setupshop.version,
+    version=setupshop._version,
     **setupshop.author_kwargs,
     **setupshop.description_kwargs,
     url="https://github.com/WIPACrepo/wipac-dev-tools",

--- a/setup.py
+++ b/setup.py
@@ -6,22 +6,17 @@ from setuptools import setup  # type: ignore[import]
 
 from wipac_dev_tools import SetupShop
 
-setupshop = SetupShop(
+shop = SetupShop(
     "wipac_dev_tools",
     os.path.abspath(os.path.dirname(__file__)),
     ((3, 6), (3, 8)),
     "WIPAC Python Development Tools",
+    allow_git_urls=False,
 )
 
 setup(
-    name=setupshop.name,
-    version=setupshop._version,
-    **setupshop.author_kwargs,
-    **setupshop.description_kwargs,
+    **shop.get_kwargs(other_classifiers=["License :: OSI Approved :: MIT License"]),
     url="https://github.com/WIPACrepo/wipac-dev-tools",
     license="MIT",
-    classifiers=setupshop.get_classifiers(["License :: OSI Approved :: MIT License"]),
-    packages=setupshop.get_packages(),
-    install_requires=setupshop.get_install_requires(allow_git_urls=False),
-    package_data={setupshop.name: ["data/www/*", "data/www_templates/*", "py.typed"]},
+    package_data={shop.name: ["data/www/*", "data/www_templates/*", "py.typed"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,118 +1,27 @@
 """Setup."""
 
-
 import os
-import sys
-from typing import List, Tuple
 
 from setuptools import setup  # type: ignore[import]
 
-HERE = os.path.abspath(os.path.dirname(__file__))
-OLDEST_PY_VERSION: Tuple[int, int] = (3, 6)
-PY_VERSION: Tuple[int, int] = (3, 8)
-NAME = "wipac_dev_tools"
-REQUIREMENTS_PATH = os.path.join(HERE, "requirements.txt")
-REQUIREMENTS = open(REQUIREMENTS_PATH).read().splitlines()
+from wipac_dev_tools import SetupShop
 
-
-# Check Python Version -----------------------------------------------------------------
-if sys.version_info < OLDEST_PY_VERSION:
-    print(
-        f"ERROR: {NAME} requires at least Python {OLDEST_PY_VERSION[0]}.{OLDEST_PY_VERSION[1]}+ to run "
-        f"( {sys.version_info} < {OLDEST_PY_VERSION} )"
-    )
-    sys.exit(1)
-
-
-# Helper Utilities ---------------------------------------------------------------------
-
-
-def _get_version() -> str:
-    with open(os.path.join(HERE, NAME, "__init__.py")) as init_f:
-        for line in init_f.readlines():
-            if "__version__" in line:
-                # grab "X.Y.Z" from "__version__ = 'X.Y.Z'" (quote-style insensitive)
-                return line.replace('"', "'").split("=")[-1].split("'")[1]
-    raise Exception("cannot find __version__")
-
-
-def _get_pypi_requirements() -> List[str]:
-    return [m.replace("==", ">=") for m in REQUIREMENTS if "git+" not in m]
-
-
-def _get_git_requirements() -> List[str]:
-    # def valid(req: str) -> bool:
-    #     pat = r"^git\+https://github\.com/[^/]+/[^/]+@(v)?\d+\.\d+\.\d+#egg=\w+$"
-    #     if not re.match(pat, req):
-    #         raise Exception(
-    #             f"from {REQUIREMENTS_PATH}: "
-    #             f"pip-install git-package url is not in standardized format {pat} ({req})"
-    #         )
-    #     return True
-
-    # return [m.replace("git+", "") for m in REQUIREMENTS if "git+" in m and valid(m)]
-    for req in REQUIREMENTS:
-        if "git+" in req:
-            raise Exception(
-                "This package cannot contain any git dependencies. "
-                "This is to prevent any circular dependencies. "
-                f"The culprit: {req} from {REQUIREMENTS_PATH}"
-            )
-    return []
-
-
-def _python_lang_classifiers() -> List[str]:
-    """NOTE: Will not work after the '3.* -> 4.0'-transition."""
-    if OLDEST_PY_VERSION[0] < 3:
-        raise Exception("Python-classifier automation does not work for python <3.")
-    if PY_VERSION[0] >= 4:
-        raise Exception("Python-classifier automation does not work for python 4+.")
-
-    return [
-        f"Programming Language :: Python :: 3.{r}"
-        for r in range(OLDEST_PY_VERSION[1], PY_VERSION[1] + 1)
-    ]
-
-
-def _development_status() -> str:
-    # "Development Status :: 1 - Planning",
-    # "Development Status :: 2 - Pre-Alpha",
-    # "Development Status :: 3 - Alpha",
-    # "Development Status :: 4 - Beta",
-    # "Development Status :: 5 - Production/Stable",
-    # "Development Status :: 6 - Mature",
-    # "Development Status :: 7 - Inactive",
-    version = _get_version()
-    if version.startswith("0.0.0"):
-        return "Development Status :: 2 - Pre-Alpha"
-    elif version.startswith("0.0."):
-        return "Development Status :: 3 - Alpha"
-    elif version.startswith("0."):
-        return "Development Status :: 4 - Beta"
-    elif int(version.split(".")[0]) >= 1:
-        return "Development Status :: 5 - Production/Stable"
-    else:
-        raise Exception(f"Could not figure Development Status for version: {version}")
-
-
-# Setup --------------------------------------------------------------------------------
+setupshop = SetupShop(
+    "wipac_dev_tools",
+    os.path.abspath(os.path.dirname(__file__)),
+    ((3, 6), (3, 8)),
+    "WIPAC Python Development Tools",
+)
 
 setup(
-    name=NAME,
-    version=_get_version(),
-    description="File Catalog",
-    long_description=open(os.path.join(HERE, "README.md")).read(),  # include new-lines
-    long_description_content_type="text/markdown",
+    name=setupshop.name,
+    version=setupshop.version,
+    **setupshop.author_kwargs,
+    **setupshop.description_kwargs,
     url="https://github.com/WIPACrepo/wipac-dev-tools",
     license="MIT",
-    classifiers=sorted(
-        _python_lang_classifiers()
-        + [_development_status()]
-        + ["License :: OSI Approved :: MIT License"]
-    ),
-    keywords="wipac dev tool",
-    packages=[NAME],
-    install_requires=_get_pypi_requirements(),
-    dependency_links=_get_git_requirements(),
-    package_data={NAME: ["data/www/*", "data/www_templates/*", "py.typed"]},
+    classifiers=setupshop.get_classifiers(["License :: OSI Approved :: MIT License"]),
+    packages=setupshop.get_packages(),
+    install_requires=setupshop.get_install_requires(allow_git_urls=False),
+    package_data={setupshop.name: ["data/www/*", "data/www_templates/*", "py.typed"]},
 )

--- a/wipac_dev_tools/__init__.py
+++ b/wipac_dev_tools/__init__.py
@@ -1,8 +1,9 @@
 """Init."""
 
 from .enviro_tools import from_environment  # noqa
+from .setup_tools import SetupShop  # noqa
 
-__all__ = ["from_environment"]
+__all__ = ["from_environment", "SetupShop"]
 
 # version is a human-readable version number.
 __version__ = "1.0.2"

--- a/wipac_dev_tools/setup_tools.py
+++ b/wipac_dev_tools/setup_tools.py
@@ -15,7 +15,7 @@ class SetupShop:
 
     Arguments:
         package_name -- the name of your package
-        path_to_setup_py -- use: `os.path.abspath(os.path.dirname(__file__))`
+        abspath_to_root -- use: `os.path.abspath(os.path.dirname(__file__))`
         py_min_max -- the min and max supported py release: Ex: `((3,6), (3,8))`
         description -- a one-line description of your package
 
@@ -29,14 +29,14 @@ class SetupShop:
     def __init__(
         self,
         package_name: str,
-        path_to_setup_py: str,
+        abspath_to_root: str,
         py_min_max: Tuple[Tuple[int, int], Tuple[int, int]],
         description: str,
         requirements_dir: str = "",
         init_version_dir: str = "",
     ):
         self.name = package_name
-        self.here = path_to_setup_py
+        self.here = abspath_to_root
         self.py_min = min(py_min_max)
         self.py_max = max(py_min_max)
         self.requirements_path = os.path.join(

--- a/wipac_dev_tools/setup_tools.py
+++ b/wipac_dev_tools/setup_tools.py
@@ -51,7 +51,7 @@ class SetupShop:
             # include new-lines
             "long_description": open(os.path.join(self.here, "README.md")).read(),
             "long_description_content_type": "text/markdown",
-            "keywords": description.split() + self.name.split(),
+            "keywords": description.split() + self.name.split("_"),
         }
 
         self._ensure_python_competibilty()

--- a/wipac_dev_tools/setup_tools.py
+++ b/wipac_dev_tools/setup_tools.py
@@ -99,18 +99,19 @@ class SetupShop:
         name: str, py_min: PythonVersion, py_max: PythonVersion
     ) -> None:
         """If current python version is not compatible, warn and/or exit."""
-        if sys.version_info < py_min:
-            print(
-                f"ERROR: {name} requires at least Python "
+        current = (sys.version_info.major, sys.version_info.minor)  # ignore micro
+
+        if current < py_min:  # Ex: 3.5.2 < 3.5
+            raise Exception(
+                f"{name} requires at least Python "
                 f"{py_min[0]}.{py_min[1]} to run "
-                f"( {sys.version_info} < {py_min} )"
+                f"(current-version={current})"
             )
-            sys.exit(1)
-        elif sys.version_info > py_max:
+        elif current > py_max:  # ignore micro
             print(
                 f"WARNING: {name} does not officially support Python "
-                f"{sys.version_info[0]}.{sys.version_info[1]}+ "
-                f"( {sys.version_info} > {py_max} )"
+                f"{current[0]}.{current[1]}+ "
+                f"(max-version={py_max})"
             )
 
     @staticmethod

--- a/wipac_dev_tools/setup_tools.py
+++ b/wipac_dev_tools/setup_tools.py
@@ -57,9 +57,10 @@ class SetupShop:
             "keywords": description.split() + self.name.split("_"),
         }
 
-        self._ensure_python_competibilty()
+        self._ensure_python_compatibility()
 
-    def _ensure_python_competibilty(self) -> None:
+    def _ensure_python_compatibility(self) -> None:
+        """If current python version is not compatible, warn and/or exit."""
         if sys.version_info < self.py_min:
             print(
                 f"ERROR: {self.name} requires at least Python "

--- a/wipac_dev_tools/setup_tools.py
+++ b/wipac_dev_tools/setup_tools.py
@@ -16,7 +16,7 @@ class SetupShop:
     Arguments:
         package_name -- the name of your package
         abspath_to_root -- use: `os.path.abspath(os.path.dirname(__file__))`
-        py_min_max -- the min and max supported py release: Ex: `((3,6), (3,8))`
+        py_min_max -- the min and max supported python releases: Ex: `((3,6), (3,8))`
         description -- a one-line description of your package
 
     Keyword arguments:

--- a/wipac_dev_tools/setup_tools.py
+++ b/wipac_dev_tools/setup_tools.py
@@ -1,0 +1,157 @@
+"""Module to support the `setuptools.setup` utility within `setup.py` files."""
+
+
+import os
+import re
+import sys
+from typing import List, Optional, Tuple
+
+
+class SetupShop:
+    """Programmatically construct arguments for use in `setuptools.setup()`.
+
+    This class is not intended to replace `setuptools.setup()`, but
+    rather supplement more complex boilerplate code and reduce errors.
+    """
+
+    def __init__(
+        self,
+        package_name: str,
+        path_to_setup_py: str,
+        py_min_max: Tuple[Tuple[int, int], Tuple[int, int]],
+        description: str,
+        requirements_dir: str = "",
+    ):
+        """Provide the minimum required info for using `SetupShop`.
+
+        Arguments:
+            package_name -- the name of your package
+            path_to_setup_py -- use: `os.path.abspath(os.path.dirname(__file__))`
+            py_min_max -- the min and max supported py release: Ex: `((3,6), (3,8))`
+            description -- a one-line description of your package
+
+        Keyword arguments:
+            requirements_dir -- a sub-directory containing `requirements.txt` (default: {""})
+                                (if `requirements.txt` is in the root, ignore this)
+        """
+        self.name = package_name
+        self.here = path_to_setup_py
+        self.py_min = min(py_min_max)
+        self.py_max = max(py_min_max)
+        self.requirements_path = os.path.join(
+            self.here, requirements_dir, "requirements.txt"
+        )
+        self.version = self._find_version()
+
+        # dicts to be used like: `**this_kwarg`
+        self.author_kwargs = {
+            "author": "IceCube Collaboration",
+            "author_email": "developers@icecube.wisc.edu",
+        }
+        self.description_kwargs = {
+            "description": description,
+            # include new-lines
+            "long_description": open(os.path.join(self.here, "README.md")).read(),
+            "long_description_content_type": "text/markdown",
+        }
+
+        self._ensure_python_competibilty()
+
+    def _ensure_python_competibilty(self) -> None:
+        if sys.version_info < self.py_min:
+            print(
+                f"ERROR: {self.name} requires at least Python "
+                f"{self.py_min[0]}.{self.py_min[1]} to run "
+                f"( {sys.version_info} < {self.py_min} )"
+            )
+            sys.exit(1)
+        elif sys.version_info > self.py_max:
+            print(
+                f"WARNING: {self.name} does not officially support Python "
+                f"{sys.version_info[0]}.{sys.version_info[1]}+ "
+                f"( {sys.version_info} > {self.py_max} )"
+            )
+
+    def _find_version(self) -> str:
+        """Grab the package's version string."""
+        with open(os.path.join(self.here, self.name, "__init__.py")) as init_f:
+            for line in init_f.readlines():
+                if "__version__" in line:
+                    # grab "X.Y.Z" from "__version__ = 'X.Y.Z'" (quote-style insensitive)
+                    return line.replace('"', "'").split("=")[-1].split("'")[1]
+
+        raise Exception("cannot find __version__")
+
+    def get_install_requires(self, allow_git_urls: bool = True) -> List[str]:
+        """Get the `install_requires` list."""
+
+        def convert(req: str) -> str:
+            # GitHub Packages
+            if "github.com" in req:
+                if not allow_git_urls:
+                    raise Exception(
+                        "This package cannot contain any git/github url dependencies. "
+                        "This is to prevent any circular dependencies. "
+                        f"The culprit: {req} from {self.requirements_path}"
+                    )
+                pat = r"^git\+(?P<url>https://github\.com/[^/]+/[^/]+)@(?P<tag>(v)?\d+\.\d+\.\d+)#egg=(?P<package>\w+)$"
+                re_match = re.match(pat, req)
+                if not re_match:
+                    raise Exception(
+                        f"from {self.requirements_path}: "
+                        f"pip-install git-package url is not in standardized format {pat} ({req})"
+                    )
+                groups = re_match.groupdict()
+                # point right to .zip (https://stackoverflow.com/a/56635563/13156561)
+                return f'{groups["package"]} @ {groups["url"]}/archive/refs/tags/{groups["tag"]}.zip'
+            # PyPI Packages
+            else:
+                return req.replace("==", ">=")
+
+        return [convert(m) for m in open(self.requirements_path).read().splitlines()]
+
+    def _get_py_classifiers(self) -> List[str]:
+        """NOTE: Will not work after the '3.* -> 4.0'-transition."""
+        if self.py_min[0] < 3:
+            raise Exception("Python-classifier automation does not work for python <3.")
+        if self.py_max[0] >= 4:
+            raise Exception("Python-classifier automation does not work for python 4+.")
+
+        return [
+            f"Programming Language :: Python :: 3.{r}"
+            for r in range(self.py_min[1], self.py_max[1] + 1)
+        ]
+
+    def _get_development_status(self) -> str:
+        """Detect the development status from the package's version.
+
+        # "Development Status :: 1 - Planning",
+        # "Development Status :: 2 - Pre-Alpha",
+        # "Development Status :: 3 - Alpha",
+        # "Development Status :: 4 - Beta",
+        # "Development Status :: 5 - Production/Stable",
+        # "Development Status :: 6 - Mature",
+        # "Development Status :: 7 - Inactive",
+        """
+        if self.version.startswith("0.0.0"):
+            return "Development Status :: 2 - Pre-Alpha"
+        elif self.version.startswith("0.0."):
+            return "Development Status :: 3 - Alpha"
+        elif self.version.startswith("0."):
+            return "Development Status :: 4 - Beta"
+        elif int(self.version.split(".")[0]) >= 1:
+            return "Development Status :: 5 - Production/Stable"
+        else:
+            raise Exception(
+                f"Could not figure Development Status for version: {self.version}"
+            )
+
+    def get_classifiers(
+        self, other_classifiers: Optional[List[str]] = None
+    ) -> List[str]:
+        """Return an aggregated list of classifiers."""
+        classifiers = self._get_py_classifiers() + [self._get_development_status()]
+        if other_classifiers:
+            classifiers.extend(other_classifiers)
+
+        return sorted(classifiers)

--- a/wipac_dev_tools/setup_tools.py
+++ b/wipac_dev_tools/setup_tools.py
@@ -63,6 +63,9 @@ class SetupShop:
         allow_git_urls: bool = True,
     ):
         py_min, py_max = min(py_min_max), max(py_min_max)
+
+        if not re.match(r"\w+$", package_name):
+            raise Exception(f"Package name contains illegal characters: {package_name}")
         self.name = package_name
 
         # Before anything else, check that the current python version is okay


### PR DESCRIPTION
The long-awaited (by me at least) utility for supplementing WIPAC dev team's `setup.py` files.

Closes https://github.com/WIPACrepo/wipac-dev-tools/issues/6:
> Essentially, this [consists] of helper-methods for setuptools.setup() arguments.
> 
> Currently, we have copies of these utility functions in many repos (with slight tweaks). These should be consolidated into this repository.
> 
> Importing repos will need to checkout this repo in a subprocess, since this will be used in setup.py.