### PR TITLE
Python Setup Additions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,19 @@ jobs:
           - checkout
           - run: pip install -r requirements.txt && pytest -vvvv --mypy --flake8 tests
 
+    try-setup-install:
+        docker:
+          - image: circleci/python:3.8
+        steps:
+          - checkout
+          - run: |
+              python3 -m virtualenv -p python3 env
+              . env/bin/activate
+              python setup.py install
+
 workflows:
     version: 2
     build_and_test:
         jobs:
             - test
+            - try-setup-install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pycycle
-pytest
+pytest==6.2.4
 pytest-flake8
 pytest-mypy

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ shop = SetupShop(
 )
 
 setup(
-    **shop.get_kwargs(other_classifiers=["License :: OSI Approved :: MIT License"]),
+    **shop.get_kwargs(),
     url="https://github.com/WIPACrepo/wipac-dev-tools",
-    license="MIT",
     package_data={shop.name: ["data/www/*", "data/www_templates/*", "py.typed"]},
 )

--- a/wipac_dev_tools/setup_tools.py
+++ b/wipac_dev_tools/setup_tools.py
@@ -27,6 +27,7 @@ class SetupShopKwargs(TypedDict):
     long_description_content_type: str
     keywords: List[str]
     classifiers: List[str]
+    license: str
     packages: List[str]
     install_requires: List[str]
 
@@ -283,7 +284,12 @@ class SetupShop:
             "long_description": self._long_description,
             "long_description_content_type": "text/markdown",
             "keywords": keywords,
-            "classifiers": sorted(self._classifiers + other_classifiers),
+            "classifiers": sorted(
+                self._classifiers
+                + other_classifiers
+                + ["License :: OSI Approved :: MIT License"]
+            ),
+            "license": "MIT",
             "packages": SetupShop._get_packages(self.name, subpackages),
             "install_requires": self._install_requires,
         }


### PR DESCRIPTION
1. Add MIT License to `SetupShop`
2. Add CircleCI job that runs `python setup.py install`. This should catch setup errors that our other tests can't. I'm planning to add this along with my other setup tools across our repos.

closes https://github.com/WIPACrepo/wipac-dev-tools/issues/9