### PR TITLE
Allow Pinned Versions for Dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pycycle
 pytest==6.2.4
 pytest-flake8
 pytest-mypy

--- a/wipac_dev_tools/setup_tools.py
+++ b/wipac_dev_tools/setup_tools.py
@@ -210,7 +210,7 @@ class SetupShop:
             # https://www.python.org/dev/peps/pep-0508/#names
             rematch = re.match(r"^[A-Za-z0-9._-]+", req)
             if not rematch:
-                raise Exception(f"Malformed package requirement line: {req}")
+                raise Exception(f"Malformed package requirement line: '{req}'")
             return rematch.group(0)
 
         def convert(req: str) -> str:


### PR DESCRIPTION
Turns off the auto-upgrading requirement (`>=`'ifying) of specified package dependencies.

closes https://github.com/WIPACrepo/wipac-dev-tools/issues/16