### PR TITLE
MyPy Support for Multiple Requirements Files

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -25,5 +25,5 @@ jobs:
       - run: |
           ([ -e "requirements-dev.txt" ] && pip install -r requirements-dev.txt) || echo "no dev reqs"
       - run: |
-          ([ -e "setup.py" ] && pip install .) || pip install -r requirements.txt
+          ([ -e "setup.py" ] && pip install .) || pip install `find . -name 'requirements.txt' | rev | sed -z 's/\n/ r- /g' | rev`
       - run: mypy --install-types --namespace-packages --non-interactive --exclude build/ .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest==6.2.5
 pytest-flake8==1.0.7
-pytest-mypy==0.8.1
+pytest-mypy==0.9.0
 requests==2.27.1


### PR DESCRIPTION
Lints (mypy) repos that have multiple `requirements.txt` files, but no `setup.py`. This change is intended to support repos with multiple packages that are executed, not imported, like https://github.com/WIPACrepo/mou-dashboard