### PR TITLE
Add Backup MyPy Script

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -26,4 +26,7 @@ jobs:
           ([ -e "requirements-dev.txt" ] && pip install -r requirements-dev.txt) || echo "no dev reqs"
       - run: |
           ([ -e "setup.py" ] && pip install .) || pip install `find . -name 'requirements.txt' | rev | sed -z 's/\n/ r- /g' | rev`
-      - run: mypy --install-types --namespace-packages --non-interactive --exclude build/ .
+      - run: |
+          flags="--namespace-packages --exclude build/"
+          it_flags="--install-types --non-interactive"
+          (mypy $it_flags $flags . 2>/dev/null) || (echo "no type-packages to install" && mypy $flags .)


### PR DESCRIPTION
There's a corner case in which mypy fails to install type-packages using `mypy --install-types --non-interactive --namespace-packages --exclude build/ .` _when mypy would already fail_ using the "normal" `mypy --namespace-packages --exclude build/ .`. 

In other words, there are mypy errors in the repo, but mypy suppresses those helpful errors in favor of the error: `error: --install-types failed (no mypy cache directory)`.

Using this update, when `--install-types --non-interactive` fails, just run the "normal" `mypy --namespace-packages --exclude build/ .`, so we can see the errors.

Yes, this may be prevented by using `--explicit-package-bases` or just pointing mypy at one directory, but these are bandaid solutions.

Before: https://github.com/WIPACrepo/rest-tools/runs/5557863598?check_suite_focus=true
After: https://github.com/WIPACrepo/rest-tools/runs/5558228631?check_suite_focus=true
After MyPy Fixes: https://github.com/WIPACrepo/rest-tools/runs/5558450724?check_suite_focus=true