### PR TITLE
A Couple Logging Tools

### DIFF
--- a/wipac_dev_tools/__init__.py
+++ b/wipac_dev_tools/__init__.py
@@ -1,9 +1,10 @@
 """Init."""
 
+from . import logging_tools
 from .enviro_tools import from_environment  # noqa
 from .setup_tools import SetupShop  # noqa
 
-__all__ = ["from_environment", "SetupShop"]
+__all__ = ["from_environment", "SetupShop", "logging_tools"]
 
 # version is a human-readable version number.
 __version__ = "1.1.5"

--- a/wipac_dev_tools/logging_tools.py
+++ b/wipac_dev_tools/logging_tools.py
@@ -12,6 +12,8 @@ def set_level(
 ) -> None:
     """Set the level of the root logger, first-party loggers, and third-party loggers.
 
+    The root logger and first-party logger(s) are set to the same level (`level`).
+
     Passing `use_coloredlogs=True` will import and use the `coloredlogs`
     package. This will set the logger format and use colored text.
     """

--- a/wipac_dev_tools/logging_tools.py
+++ b/wipac_dev_tools/logging_tools.py
@@ -10,7 +10,11 @@ def set_level(
     third_party_level: str = "WARNING",
     use_coloredlogs: bool = False,
 ) -> None:
-    """Set the level of the root logger, first-party loggers, and third-party loggers."""
+    """Set the level of the root logger, first-party loggers, and third-party loggers.
+
+    Passing `use_coloredlogs=True` will import and use the `coloredlogs`
+    package. This will set the logger format and use colored text.
+    """
     if not first_party_loggers:
         first_party_loggers = []
 

--- a/wipac_dev_tools/logging_tools.py
+++ b/wipac_dev_tools/logging_tools.py
@@ -1,7 +1,37 @@
 """Common tools to supplement/assist the standard logging package."""
 
+import argparse
 import logging
 from typing import List, Optional, Union
+
+
+def log_argparse_args(
+    args: argparse.Namespace,
+    logger: Optional[Union[str, logging.Logger]] = None,
+    level: str = "warning",
+) -> argparse.Namespace:
+    """Log the argparse args and their values at the given level.
+
+    Return the args (Namespace) unchanged.
+
+    Example:
+        2022-05-13 22:37:21 fv-az136-643 my-logs[61] WARNING in_file: in_msg.pkl
+        2022-05-13 22:37:21 fv-az136-643 my-logs[61] WARNING out_file: out_msg.pkl
+        2022-05-13 22:37:21 fv-az136-643 my-logs[61] WARNING log: DEBUG
+        2022-05-13 22:37:21 fv-az136-643 my-logs[61] WARNING log_third_party: WARNING
+    """
+    if not logger:
+        _logger = logging.getLogger()
+    elif isinstance(logger, logging.Logger):
+        _logger = logger
+    else:
+        _logger = logging.getLogger(logger)
+
+    log = getattr(_logger, level.lower())  # ..., info, warning, critical, ...
+    for arg, val in vars(args).items():
+        log(f"{arg}: {val}")
+
+    return args
 
 
 def set_level(

--- a/wipac_dev_tools/logging_tools.py
+++ b/wipac_dev_tools/logging_tools.py
@@ -4,11 +4,15 @@ import argparse
 import logging
 from typing import List, Optional, Union
 
+from typing_extensions import Literal  # will redirect to Typing for 3.8+
+
+LoggerLevel = Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
+
 
 def log_argparse_args(
     args: argparse.Namespace,
     logger: Optional[Union[str, logging.Logger]] = None,
-    level: str = "warning",
+    level: LoggerLevel = "WARNING",
 ) -> argparse.Namespace:
     """Log the argparse args and their values at the given level.
 
@@ -37,7 +41,7 @@ def log_argparse_args(
 def set_level(
     level: str,
     first_party_loggers: Optional[List[Union[str, logging.Logger]]] = None,
-    third_party_level: str = "WARNING",
+    third_party_level: LoggerLevel = "WARNING",
     use_coloredlogs: bool = False,
 ) -> None:
     """Set the level of the root logger, first-party loggers, and third-party loggers.

--- a/wipac_dev_tools/logging_tools.py
+++ b/wipac_dev_tools/logging_tools.py
@@ -1,0 +1,38 @@
+"""Common tools to supplement/assist the standard logging package."""
+
+import logging
+from typing import List, Optional, Union
+
+
+def set_level(
+    level: str,
+    first_party_loggers: Optional[List[Union[str, logging.Logger]]] = None,
+    third_party_level: str = "WARNING",
+    use_coloredlogs: bool = False,
+) -> None:
+    """Set the level of the root logger, first-party loggers, and third-party loggers."""
+    if not first_party_loggers:
+        first_party_loggers = []
+
+    # root
+    if use_coloredlogs:
+        import coloredlogs  # type: ignore[import]  # pylint: disable=import-outside-toplevel
+
+        coloredlogs.install(level=level)  # root
+    else:
+        logging.getLogger().setLevel(level)
+
+    # first-party
+    for log in first_party_loggers:
+        if isinstance(log, logging.Logger):
+            log.setLevel(level)
+        else:  # str
+            logging.getLogger(log).setLevel(level)
+
+    # third-party
+    for log_name in logging.root.manager.loggerDict:
+        if log_name in first_party_loggers:
+            continue
+        if logging.getLogger(log_name) in first_party_loggers:
+            continue
+        logging.getLogger(log_name).setLevel(third_party_level)


### PR DESCRIPTION
Adds `logging_tools` with functions:
- `log_argparse_args(args, logger=None, level="warning")`
	+ Example:
	```
	2022-05-13 22:37:21 fv-az136-643 my-logs[61] WARNING in_file: in_msg.pkl
    2022-05-13 22:37:21 fv-az136-643 my-logs[61] WARNING out_file: out_msg.pkl
    2022-05-13 22:37:21 fv-az136-643 my-logs[61] WARNING log: DEBUG
    2022-05-13 22:37:21 fv-az136-643 my-logs[61] WARNING log_third_party: WARNING
	```
- `set_level(level, first_party_loggers=None, third_party_level="WARNING", use_coloredlogs=False)`
	+ Set the level of the root logger, first-party loggers, and third-party loggers.
	+    The root logger and first-party logger(s) are set to the same level (`level`).
    + Passing `use_coloredlogs=True` will import and use the `coloredlogs`
    package. This will set the logger format and use colored text.