### PR TITLE
`argparse_tools`: Auto-wrap `ArgumentTypeError` If Needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
     # via requests

--- a/wipac_dev_tools/argparse_tools.py
+++ b/wipac_dev_tools/argparse_tools.py
@@ -12,7 +12,7 @@ def validate_arg(val: T, test: bool, exc: Exception) -> T:
 
     If the passed exception is not an instance of `ArgumentTypeError`,
     `TypeError`, or `ValueError`, then an `ArgumentTypeError` instance
-    is raised, like so: `ArgumentTypeError(str(exc))`
+    is raised, like so: `ArgumentTypeError(repr(exc))`
     """
     if test:
         return val
@@ -22,7 +22,7 @@ def validate_arg(val: T, test: bool, exc: Exception) -> T:
     # the exception is caught and a nicely formatted error message is displayed.
     # No other exception types are handled.
     if not isinstance(exc, (argparse.ArgumentTypeError, TypeError, ValueError)):
-        raise argparse.ArgumentTypeError(str(exc))
+        raise argparse.ArgumentTypeError(repr(exc))
 
     raise exc
 

--- a/wipac_dev_tools/argparse_tools.py
+++ b/wipac_dev_tools/argparse_tools.py
@@ -11,8 +11,8 @@ def validate_arg(val: T, test: bool, exc: Exception) -> T:
     """Validation `val` by checking `test` and raise `exc` if that is falsy.
 
     If the passed exception is not an instance of `ArgumentTypeError`,
-    `TypeError`, or `ValueError`, then an `ArgumentTypeError` instance
-    is raised, like so: `ArgumentTypeError(repr(exc))`
+    then an `ArgumentTypeError` instance is raised, like so:
+        `ArgumentTypeError(f"{repr(exc)} [{val}]")`
     """
     if test:
         return val
@@ -21,8 +21,8 @@ def validate_arg(val: T, test: bool, exc: Exception) -> T:
     # If the function raises ArgumentTypeError, TypeError, or ValueError,
     # the exception is caught and a nicely formatted error message is displayed.
     # No other exception types are handled.
-    if not isinstance(exc, (argparse.ArgumentTypeError, TypeError, ValueError)):
-        raise argparse.ArgumentTypeError(repr(exc))
+    if not isinstance(exc, argparse.ArgumentTypeError):
+        raise argparse.ArgumentTypeError(f"{repr(exc)} [{val}]")
 
     raise exc
 

--- a/wipac_dev_tools/argparse_tools.py
+++ b/wipac_dev_tools/argparse_tools.py
@@ -1,5 +1,6 @@
 """Simple tools used with argparse."""
 
+import argparse
 from pathlib import Path
 from typing import Optional, TypeVar
 
@@ -7,9 +8,22 @@ T = TypeVar("T")
 
 
 def validate_arg(val: T, test: bool, exc: Exception) -> T:
-    """Validation `val` by checking `test` and raise `exc` if that is falsy."""
+    """Validation `val` by checking `test` and raise `exc` if that is falsy.
+
+    If the passed exception is not an instance of `ArgumentTypeError`,
+    `TypeError`, or `ValueError`, then an `ArgumentTypeError` instance
+    is raised, like so: `ArgumentTypeError(str(exc))`
+    """
     if test:
         return val
+
+    # The argument to type can be any callable that accepts a single string.
+    # If the function raises ArgumentTypeError, TypeError, or ValueError,
+    # the exception is caught and a nicely formatted error message is displayed.
+    # No other exception types are handled.
+    if not isinstance(exc, (argparse.ArgumentTypeError, TypeError, ValueError)):
+        raise argparse.ArgumentTypeError(str(exc))
+
     raise exc
 
 


### PR DESCRIPTION
Example:
```
$ python ~/repos/wipac-dev-py-setup-action/setup_builder.py setuuuup.cfg wipacfoo/zoop  --license foo --base-keywords baz --directory-exclude baz
usage: setup_builder.py [-h] --base-keywords [BASE_KEYWORDS ...] --directory-exclude [DIRECTORY_EXCLUDE ...] --license LICENSE
                        setup_cfg_file github_full_repo
setup_builder.py: error: argument setup_cfg_file: FileNotFoundError('setup.cfg') [setuuuup.cfg]
```