### PR TITLE
Create `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"  # bump GHA packages
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    commit-message:
+      prefix: "dependabot: "
+      include: ""  # as opposed to "scope" which brings in the version numbers (excluding b/c WIPACrepo/wipac-dev-py-setup-action may inc. other deps)
+    open-pull-requests-limit: 1  # this is per ecosystem
+      
+  - package-ecosystem: "pip"  # bump python deps
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    commit-message:
+      prefix: "dependabot: "
+      include: ""  # as opposed to "scope" which brings in the version numbers (excluding b/c WIPACrepo/wipac-dev-py-setup-action may inc. other deps)
+    versioning-strategy: increase-if-necessary  # this allows not-exactly-equals pip notations (~=, ==v1.2.*, etc.)
+    open-pull-requests-limit: 1  # this is per ecosystem


### PR DESCRIPTION
We'll have to wait and see how this works in production, but there's no doubt that Dependabot is a mature product.