### PR TITLE
Env Vars: Add Support for `|`-syntax Optional Types

### DIFF
--- a/dependencies-dev.log
+++ b/dependencies-dev.log
@@ -7,60 +7,56 @@
 #  pip freeze
 ########################################################################
 attrs==24.2.0
-certifi==2024.7.4
+certifi==2024.8.30
 charset-normalizer==3.3.2
-filelock==3.15.4
+filelock==3.16.0
 flake8==5.0.4
-idna==3.7
+idna==3.8
 iniconfig==2.0.0
 mccabe==0.7.0
-mypy==1.11.1
+mypy==1.11.2
 mypy-extensions==1.0.0
 packaging==24.1
 pluggy==1.5.0
 pycodestyle==2.9.1
 pyflakes==2.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-flake8==1.2.2
 pytest-mypy==0.10.3
 requests==2.32.3
 semantic-version==2.10.0
-setuptools==72.1.0
 typing_extensions==4.12.2
-urllib3==2.2.2
-wheel==0.44.0
+urllib3==2.2.3
 ########################################################################
 #  pipdeptree
 ########################################################################
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pytest-flake8==1.2.2
 ├── flake8 [required: >=5,<6, installed: 5.0.4]
 │   ├── mccabe [required: >=0.7.0,<0.8.0, installed: 0.7.0]
 │   ├── pycodestyle [required: >=2.9.0,<2.10.0, installed: 2.9.1]
 │   └── pyflakes [required: >=2.5.0,<2.6.0, installed: 2.5.0]
-└── pytest [required: >=7.0, installed: 8.3.2]
+└── pytest [required: >=7.0, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 pytest-mypy==0.10.3
 ├── attrs [required: >=19.0, installed: 24.2.0]
-├── filelock [required: >=3.0, installed: 3.15.4]
-├── mypy [required: >=0.900, installed: 1.11.1]
+├── filelock [required: >=3.0, installed: 3.16.0]
+├── mypy [required: >=0.900, installed: 1.11.2]
 │   ├── mypy-extensions [required: >=1.0.0, installed: 1.0.0]
 │   └── typing_extensions [required: >=4.6.0, installed: 4.12.2]
-└── pytest [required: >=6.2, installed: 8.3.2]
+└── pytest [required: >=6.2, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 semantic-version==2.10.0
-setuptools==72.1.0
-wheel==0.44.0
 wipac-dev-tools
 ├── requests [required: Any, installed: 2.32.3]
-│   ├── certifi [required: >=2017.4.17, installed: 2024.7.4]
+│   ├── certifi [required: >=2017.4.17, installed: 2024.8.30]
 │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   ├── idna [required: >=2.5,<4, installed: 3.7]
-│   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   ├── idna [required: >=2.5,<4, installed: 3.8]
+│   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.3]
 └── typing_extensions [required: Any, installed: 4.12.2]

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -7,60 +7,56 @@
 #  pip freeze
 ########################################################################
 attrs==24.2.0
-certifi==2024.7.4
+certifi==2024.8.30
 charset-normalizer==3.3.2
-filelock==3.15.4
+filelock==3.16.0
 flake8==5.0.4
-idna==3.7
+idna==3.8
 iniconfig==2.0.0
 mccabe==0.7.0
-mypy==1.11.1
+mypy==1.11.2
 mypy-extensions==1.0.0
 packaging==24.1
 pluggy==1.5.0
 pycodestyle==2.9.1
 pyflakes==2.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-flake8==1.2.2
 pytest-mypy==0.10.3
 requests==2.32.3
 semantic-version==2.10.0
-setuptools==72.1.0
 typing_extensions==4.12.2
-urllib3==2.2.2
-wheel==0.44.0
+urllib3==2.2.3
 ########################################################################
 #  pipdeptree
 ########################################################################
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pytest-flake8==1.2.2
 ├── flake8 [required: >=5,<6, installed: 5.0.4]
 │   ├── mccabe [required: >=0.7.0,<0.8.0, installed: 0.7.0]
 │   ├── pycodestyle [required: >=2.9.0,<2.10.0, installed: 2.9.1]
 │   └── pyflakes [required: >=2.5.0,<2.6.0, installed: 2.5.0]
-└── pytest [required: >=7.0, installed: 8.3.2]
+└── pytest [required: >=7.0, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 pytest-mypy==0.10.3
 ├── attrs [required: >=19.0, installed: 24.2.0]
-├── filelock [required: >=3.0, installed: 3.15.4]
-├── mypy [required: >=0.900, installed: 1.11.1]
+├── filelock [required: >=3.0, installed: 3.16.0]
+├── mypy [required: >=0.900, installed: 1.11.2]
 │   ├── mypy-extensions [required: >=1.0.0, installed: 1.0.0]
 │   └── typing_extensions [required: >=4.6.0, installed: 4.12.2]
-└── pytest [required: >=6.2, installed: 8.3.2]
+└── pytest [required: >=6.2, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 semantic-version==2.10.0
-setuptools==72.1.0
-wheel==0.44.0
 wipac-dev-tools
 ├── requests [required: Any, installed: 2.32.3]
-│   ├── certifi [required: >=2017.4.17, installed: 2024.7.4]
+│   ├── certifi [required: >=2017.4.17, installed: 2024.8.30]
 │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   ├── idna [required: >=2.5,<4, installed: 3.7]
-│   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   ├── idna [required: >=2.5,<4, installed: 3.8]
+│   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.3]
 └── typing_extensions [required: Any, installed: 4.12.2]

--- a/dependencies-semver.log
+++ b/dependencies-semver.log
@@ -6,28 +6,24 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2024.7.4
+certifi==2024.8.30
 charset-normalizer==3.3.2
-idna==3.7
+idna==3.8
 requests==2.32.3
 semantic-version==2.10.0
-setuptools==72.1.0
 typing_extensions==4.12.2
-urllib3==2.2.2
-wheel==0.44.0
+urllib3==2.2.3
 ########################################################################
 #  pipdeptree
 ########################################################################
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 semantic-version==2.10.0
-setuptools==72.1.0
-wheel==0.44.0
 wipac-dev-tools
 ├── requests [required: Any, installed: 2.32.3]
-│   ├── certifi [required: >=2017.4.17, installed: 2024.7.4]
+│   ├── certifi [required: >=2017.4.17, installed: 2024.8.30]
 │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   ├── idna [required: >=2.5,<4, installed: 3.7]
-│   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   ├── idna [required: >=2.5,<4, installed: 3.8]
+│   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.3]
 └── typing_extensions [required: Any, installed: 4.12.2]

--- a/dependencies.log
+++ b/dependencies.log
@@ -6,26 +6,22 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2024.7.4
+certifi==2024.8.30
 charset-normalizer==3.3.2
-idna==3.7
+idna==3.8
 requests==2.32.3
-setuptools==72.1.0
 typing_extensions==4.12.2
-urllib3==2.2.2
-wheel==0.44.0
+urllib3==2.2.3
 ########################################################################
 #  pipdeptree
 ########################################################################
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
-setuptools==72.1.0
-wheel==0.44.0
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 wipac-dev-tools
 ├── requests [required: Any, installed: 2.32.3]
-│   ├── certifi [required: >=2017.4.17, installed: 2024.7.4]
+│   ├── certifi [required: >=2017.4.17, installed: 2024.8.30]
 │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   ├── idna [required: >=2.5,<4, installed: 3.7]
-│   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   ├── idna [required: >=2.5,<4, installed: 3.8]
+│   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.3]
 └── typing_extensions [required: Any, installed: 4.12.2]

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -537,7 +537,7 @@ if sys.version_info >= (3, 10):
         None | bool,
     ]
 else:
-    extra_params = []
+    extra_params = []  # type: ignore[var-annotated]
 
 
 @pytest.mark.parametrize(

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -7,7 +7,7 @@ import pathlib
 import shutil
 import tempfile
 import unittest
-from typing import Any, Dict, FrozenSet, List, Optional, Set
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Union
 
 import pytest
 from typing_extensions import Final
@@ -529,39 +529,69 @@ def test_051__final_dict_str_int() -> None:
     assert config.FOO == {"bar": 2, "baz": 3, "foo": 1}
 
 
+@pytest.mark.parametrize(
+    "typo",
+    [
+        Optional[bool],
+        Union[bool, None],
+        Union[None, bool],
+        bool | None,
+        None | bool,
+    ],
+)
 @pytest.mark.usefixtures("isolated_env")
-def test_052__optional_bool() -> None:
+def test_060__optional_bool(typo) -> None:
     """Test normal use case."""
 
     @dc.dataclass(frozen=True)
     class Config:
-        FOO: Optional[bool]
+        FOO: typo  # type: ignore
 
     os.environ["FOO"] = "T"
     config = from_environment_as_dataclass(Config)
     assert config.FOO is True
 
 
+@pytest.mark.parametrize(
+    "typo",
+    [
+        Optional[Dict[str, int]],
+        Union[Dict[str, int], None],
+        Union[None, Dict[str, int]],
+        Dict[str, int] | None,
+        None | Dict[str, int],
+    ],
+)
 @pytest.mark.usefixtures("isolated_env")
-def test_053__optional_dict_str_int() -> None:
+def test_061__optional_dict_str_int(typo) -> None:
     """Test normal use case."""
 
     @dc.dataclass(frozen=True)
     class Config:
-        FOO: Optional[Dict[str, int]]
+        FOO: typo  # type: ignore
 
     os.environ["FOO"] = "foo=1 bar=2 baz=3"
     config = from_environment_as_dataclass(Config)
     assert config.FOO == {"bar": 2, "baz": 3, "foo": 1}
 
 
+@pytest.mark.parametrize(
+    "typo",
+    [
+        Optional[dict],
+        Union[dict, None],
+        Union[None, dict],
+        dict | None,
+        None | dict,
+    ],
+)
 @pytest.mark.usefixtures("isolated_env")
-def test_054__optional_dict() -> None:
+def test_062__optional_dict(typo) -> None:
     """Test normal use case."""
 
     @dc.dataclass(frozen=True)
     class Config:
-        FOO: Optional[dict]
+        FOO: typo  # type: ignore
 
     os.environ["FOO"] = "foo=1 bar=2 baz=3"
     config = from_environment_as_dataclass(Config)

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -685,9 +685,9 @@ def test_105_error__overly_nested_type_alias() -> None:
         from_environment_as_dataclass(Config)
     assert str(cm.value) == (
         "'typing.List[typing.Dict[str, int]]' is not a "
-        "supported type: field='FOO' (the typing-module's alias types "
-        "must resolve to 'type' within 1 nesting, or 2 if using "
-        "'Final' or 'Optional')"
+        "supported type: field='FOO' (typehints "
+        "must resolve to 'type' within 1 nesting, or "
+        "2 if using 'Final', 'Optional', or a None-'Union' pairing)"
     )
 
 

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -5,6 +5,7 @@ import dataclasses as dc
 import os
 import pathlib
 import shutil
+import sys
 import tempfile
 import unittest
 from typing import Any, Dict, FrozenSet, List, Optional, Set, Union
@@ -529,15 +530,24 @@ def test_051__final_dict_str_int() -> None:
     assert config.FOO == {"bar": 2, "baz": 3, "foo": 1}
 
 
+if sys.version_info >= (3, 10):
+    # this trips up the py <3.9 interpreter
+    extra_params = [
+        bool | None,
+        None | bool,
+    ]
+else:
+    extra_params = []
+
+
 @pytest.mark.parametrize(
     "typo",
     [
         Optional[bool],
         Union[bool, None],
         Union[None, bool],
-        bool | None,
-        None | bool,
-    ],
+    ]
+    + extra_params,  # type: ignore
 )
 @pytest.mark.usefixtures("isolated_env")
 def test_060__optional_bool(typo) -> None:
@@ -552,15 +562,24 @@ def test_060__optional_bool(typo) -> None:
     assert config.FOO is True
 
 
+if sys.version_info >= (3, 10):
+    # this trips up the py <3.9 interpreter
+    extra_params = [
+        Dict[str, int] | None,
+        None | Dict[str, int],
+    ]
+else:
+    extra_params = []
+
+
 @pytest.mark.parametrize(
     "typo",
     [
         Optional[Dict[str, int]],
         Union[Dict[str, int], None],
         Union[None, Dict[str, int]],
-        Dict[str, int] | None,
-        None | Dict[str, int],
-    ],
+    ]
+    + extra_params,  # type: ignore
 )
 @pytest.mark.usefixtures("isolated_env")
 def test_061__optional_dict_str_int(typo) -> None:
@@ -575,15 +594,24 @@ def test_061__optional_dict_str_int(typo) -> None:
     assert config.FOO == {"bar": 2, "baz": 3, "foo": 1}
 
 
+if sys.version_info >= (3, 10):
+    # this trips up the py <3.9 interpreter
+    extra_params = [
+        dict | None,
+        None | dict,
+    ]
+else:
+    extra_params = []
+
+
 @pytest.mark.parametrize(
     "typo",
     [
         Optional[dict],
         Union[dict, None],
         Union[None, dict],
-        dict | None,
-        None | dict,
-    ],
+    ]
+    + extra_params,  # type: ignore
 )
 @pytest.mark.usefixtures("isolated_env")
 def test_062__optional_dict(typo) -> None:

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -361,10 +361,9 @@ def deconstruct_typehint(
             f"valid environment variable types)"
         )
     too_nested_error_msg = (
-        f"'{field.type}' is not a supported type: "
-        f"field='{field.name}' (the typing-module's alias "
-        f"types must resolve to 'type' within 1 nesting, "
-        f"or 2 if using 'Final' or 'Optional' [or None-'Union'])"
+        f"'{field.type}' is not a supported type: field='{field.name}' "
+        f"(typehints must resolve to 'type' within 1 nesting, "
+        f"or 2 if using 'Final', 'Optional', or a None-'Union' pairing)"
     )
     if not isinstance(typ, type):
         raise ValueError(too_nested_error_msg)

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -312,7 +312,7 @@ def _check_invalid_typehints(
     typ_args: tuple,
     field: dataclasses.Field,
 ):
-    if isinstance(check_typehint, _SpecialForm):
+    if isinstance(check_typehint, _SpecialForm) and not typ_args:
         # ERROR: detect bare 'Final' and 'Optional'
         raise ValueError(
             f"'{field.type}' is not a supported type: "
@@ -343,7 +343,6 @@ def deconstruct_typehint(
     field: dataclasses.Field,
 ) -> Tuple[type, Optional[Tuple[type, ...]]]:
     """Take a type hint and return its type and its arguments' types."""
-
     _check_invalid_typehints(field.type, tuple(), field)
 
     if isinstance(field.type, (GenericAlias, types.GenericAlias)):

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -282,7 +282,10 @@ def from_environment_as_dataclass(
     )
 
 
-def _resolve_optional(typ_origin, typ_args):
+def _resolve_optional(
+    typ_origin: Any,  # at this point, types kind of break down since there is no common base-type among the many variations
+    typ_args: tuple,
+):
     # Optional[bool] *is* typing.Union[bool, NoneType]
     # similarly...
     #   Optional[bool]
@@ -300,7 +303,10 @@ def _resolve_optional(typ_origin, typ_args):
         return None
 
 
-def _resolve_final(typ_origin, typ_args):
+def _resolve_final(
+    typ_origin: Any,  # at this point, types kind of break down since there is no common base-type among the many variations
+    typ_args: tuple,
+):
     if typ_origin == Final:
         return typ_args[0]
     else:
@@ -308,25 +314,25 @@ def _resolve_final(typ_origin, typ_args):
 
 
 def _check_invalid_typehints(
-    check_typehint,
+    typ_origin: Any,  # at this point, types kind of break down since there is no common base-type among the many variations
     typ_args: tuple,
     field: dataclasses.Field,
 ):
-    if isinstance(check_typehint, _SpecialForm) and not typ_args:
+    if isinstance(typ_origin, _SpecialForm) and not typ_args:
         # ERROR: detect bare 'Final' and 'Optional'
         raise ValueError(
             f"'{field.type}' is not a supported type: "
             f"field='{field.name}' (any of the typing-module's SpecialForm "
             f"types, 'Final' and 'Optional', must have a nested type attached)"
         )
-    elif check_typehint is Any:
+    elif typ_origin is Any:
         # ERROR: Any is not ok
         raise ValueError(
             f"'{field.type}' is not a supported type: "
             f"field='{field.name}' (the 'Any' type and subclasses are not "
             f"valid environment variable types)"
         )
-    elif check_typehint == Union and (len(typ_args) != 2 or type(None) not in typ_args):
+    elif typ_origin == Union and (len(typ_args) != 2 or type(None) not in typ_args):
         # ERROR: disallowed Union usage (only single w/ None ok)
         raise ValueError(
             f"'{field.type}' is not a supported type: "

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -5,6 +5,7 @@ import dataclasses
 import logging
 import os
 import re
+import sys
 import types
 from typing import (
     Any,
@@ -356,7 +357,7 @@ def deconstruct_typehint(
         #   List[int]     -> list, [int]
         #   dict[str,int] -> dict, [str,int]
         typ_origin, typ_args = field.type.__origin__, field.type.__args__
-    elif isinstance(field.type, types.UnionType):
+    elif sys.version_info >= (3, 10) and isinstance(field.type, types.UnionType):
         # Ex:
         #   None | int, bool | str, ...
         typ_origin, typ_args = Union, field.type.__args__


### PR DESCRIPTION
Previous docs said that `from_environment_as_dataclass()` supports optional / None-union typehints. While this _was_ true, more ways exist to define an optional type, like `int | None`. This PR adds that support.