### PR TITLE
`timing_tools.py`: Decrease Logging More

### DIFF
--- a/wipac_dev_tools/timing_tools.py
+++ b/wipac_dev_tools/timing_tools.py
@@ -30,10 +30,10 @@ class IntervalTimer:
             self.logger = logging.getLogger(logger)
 
     def fastforward(self):
-        """Reset the timer so that the next call to `has_interval_elapsed` will return True.
+        """Force the interval timer to consider the current interval as already elapsed.
 
-        This effectively skips the current interval and forces the timer to indicate
-        that the interval has elapsed on the next check.
+        This resets the internal timer to a state where the next call to `has_interval_elapsed`
+        will immediately return `True`, as if the interval has already passed.
         """
         self._last_time = float("-inf")
 

--- a/wipac_dev_tools/timing_tools.py
+++ b/wipac_dev_tools/timing_tools.py
@@ -58,8 +58,9 @@ class IntervalTimer:
             self.logger.debug(
                 f"Waiting until {self.seconds}s has elapsed since the last iteration..."
             )
+
         for i in itertools.count():
-            if not self.has_interval_elapsed(do_log=self._is_every_n(i, log_every_n)):
+            if self.has_interval_elapsed(do_log=self._is_every_n(i, log_every_n)):
                 return
             await asyncio.sleep(frequency)
 
@@ -77,8 +78,9 @@ class IntervalTimer:
             self.logger.debug(
                 f"Waiting until {self.seconds}s has elapsed since the last iteration..."
             )
+
         for i in itertools.count():
-            if not self.has_interval_elapsed(do_log=self._is_every_n(i, log_every_n)):
+            if self.has_interval_elapsed(do_log=self._is_every_n(i, log_every_n)):
                 return
             time.sleep(frequency)
 
@@ -90,9 +92,9 @@ class IntervalTimer:
         diff = time.monotonic() - self._last_time
         if diff >= self.seconds:
             self._last_time = time.monotonic()
-            if self.logger:
+            if self.logger and do_log:
                 self.logger.debug(
-                    f"At least {self.seconds}s have elapsed (actually {diff}s)."
+                    f"Interval elapsed: {self.seconds}s (actual: {diff:.3f}s)."
                 )
             return True
         return False

--- a/wipac_dev_tools/timing_tools.py
+++ b/wipac_dev_tools/timing_tools.py
@@ -56,7 +56,7 @@ class IntervalTimer:
         """
         if self.logger:
             self.logger.debug(
-                f"Waiting until {self.seconds}s has elapsed since the last iteration..."
+                f"Waiting for {self.seconds}s interval before proceeding..."
             )
 
         for i in itertools.count():
@@ -76,7 +76,7 @@ class IntervalTimer:
         """
         if self.logger:
             self.logger.debug(
-                f"Waiting until {self.seconds}s has elapsed since the last iteration..."
+                f"Waiting for {self.seconds}s interval before proceeding..."
             )
 
         for i in itertools.count():

--- a/wipac_dev_tools/timing_tools.py
+++ b/wipac_dev_tools/timing_tools.py
@@ -84,7 +84,7 @@ class IntervalTimer:
                 return
             time.sleep(frequency)
 
-    def has_interval_elapsed(self, do_log: bool = False) -> bool:
+    def has_interval_elapsed(self, do_log: bool = True) -> bool:
         """Check if the specified time interval has elapsed since the last expiration.
 
         If the interval has elapsed, the internal timer is reset to the current time.

--- a/wipac_dev_tools/timing_tools.py
+++ b/wipac_dev_tools/timing_tools.py
@@ -38,8 +38,8 @@ class IntervalTimer:
         self._last_time = float("-inf")
 
     @staticmethod
-    def _is_nth(i: int, log_every_nth: int) -> bool:
-        return log_every_nth > 0 and i % log_every_nth == 0
+    def _is_nth(i: int, nth: int) -> bool:
+        return nth > 0 and i % nth == 0
 
     async def wait_until_interval(
         self,

--- a/wipac_dev_tools/timing_tools.py
+++ b/wipac_dev_tools/timing_tools.py
@@ -38,16 +38,13 @@ class IntervalTimer:
         self._last_time = float("-inf")
 
     @staticmethod
-    def _is_every_n(i: int, log_every_n: int) -> bool:
-        if log_every_n < 1:
-            return False
-        else:
-            return i % log_every_n == 0
+    def _is_nth(i: int, log_every_nth: int) -> bool:
+        return log_every_nth > 0 and i % log_every_nth == 0
 
     async def wait_until_interval(
         self,
         frequency: float = 1.0,
-        log_every_n: int = 60,
+        log_every_nth: int = 60,
     ) -> None:
         """Wait asynchronously until the specified interval has elapsed.
 
@@ -60,14 +57,14 @@ class IntervalTimer:
             )
 
         for i in itertools.count():
-            if self.has_interval_elapsed(do_log=self._is_every_n(i, log_every_n)):
+            if self.has_interval_elapsed(do_log=self._is_nth(i, log_every_nth)):
                 return
             await asyncio.sleep(frequency)
 
     def wait_until_interval_sync(
         self,
         frequency: float = 1.0,
-        log_every_n: int = 60,
+        log_every_nth: int = 60,
     ) -> None:
         """Wait until the specified interval has elapsed.
 
@@ -80,7 +77,7 @@ class IntervalTimer:
             )
 
         for i in itertools.count():
-            if self.has_interval_elapsed(do_log=self._is_every_n(i, log_every_n)):
+            if self.has_interval_elapsed(do_log=self._is_nth(i, log_every_nth)):
                 return
             time.sleep(frequency)
 


### PR DESCRIPTION
Continuing the work in #113, decrease the logging frequency for `wait_until_interval()` and `wait_until_interval_sync()`.