### PR TITLE
Add `Literal`-type Support to `enviro_tools`

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           ref: ${{ github.ref }}  # dont lock to sha (action needs to push)
-      - uses: WIPACrepo/wipac-dev-py-setup-action@v5.2
+      - uses: WIPACrepo/wipac-dev-py-setup-action@v5.3
         with:
           mode: PACKAGING_AND_PYPI
           python_min: 3.9

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -847,8 +847,8 @@ def test_111__literal_dict() -> None:
     with pytest.raises(ValueError) as cm:
         from_environment_as_dataclass(Config)
     assert str(cm.value).startswith(
-        "'typing.List[typing.Dict[str, int]]' is not a "
-        "supported type: field='FOO' (typehints "
+        "'dict[typing.Literal['greeting'], typing.Literal['hello', 'hi', 'howdy']]' "
+        "is not a supported type: field='FOO' (typehints "
         "must resolve to 'type' within 1 nesting, or "
         "2 if using 'Final', 'Optional', or a None-'Union' pairing)"
     )

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -656,7 +656,7 @@ def test_070__literal() -> None:
 
     @dc.dataclass(frozen=True)
     class Config:
-        FOO: Literal["hello", "hi", "howdy"]
+        FOO: Literal["english", "spanish", "french"]
 
     os.environ["FOO"] = "hello"
     config = from_environment_as_dataclass(Config)

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -664,6 +664,19 @@ def test_070__literal() -> None:
 
 
 @pytest.mark.usefixtures("isolated_env")
+def test_071__literal_dict() -> None:
+    """Test normal use case."""
+
+    @dc.dataclass(frozen=True)
+    class Config:
+        FOO: dict[Literal["greeting"], Literal["hello", "hi", "howdy"]]
+
+    os.environ["FOO"] = "greeting:hello"
+    config = from_environment_as_dataclass(Config)
+    assert config.FOO == {"greeting": "hello"}
+
+
+@pytest.mark.usefixtures("isolated_env")
 def test_100_error__missing_required() -> None:
     """Test error use case."""
 

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -658,9 +658,9 @@ def test_070__literal() -> None:
     class Config:
         FOO: Literal["english", "spanish", "french"]
 
-    os.environ["FOO"] = "hello"
+    os.environ["FOO"] = "english"
     config = from_environment_as_dataclass(Config)
-    assert config.FOO == "hello"
+    assert config.FOO == "english"
 
 
 @pytest.mark.usefixtures("isolated_env")

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-from typing import Any, Dict, FrozenSet, List, Optional, Set, Union
+from typing import Any, Dict, FrozenSet, List, Literal, Optional, Set, Union
 
 import pytest
 from typing_extensions import Final
@@ -648,6 +648,19 @@ def test_062__optional_dict(typo) -> None:
     os.environ["FOO"] = "foo=1 bar=2 baz=3"
     config = from_environment_as_dataclass(Config)
     assert config.FOO == {"bar": "2", "baz": "3", "foo": "1"}
+
+
+@pytest.mark.usefixtures("isolated_env")
+def test_070__literal() -> None:
+    """Test normal use case."""
+
+    @dc.dataclass(frozen=True)
+    class Config:
+        FOO: Literal["hello", "hi", "howdy"]
+
+    os.environ["FOO"] = "hello"
+    config = from_environment_as_dataclass(Config)
+    assert config.FOO == "hello"
 
 
 @pytest.mark.usefixtures("isolated_env")

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -664,19 +664,6 @@ def test_070__literal() -> None:
 
 
 @pytest.mark.usefixtures("isolated_env")
-def test_071__literal_dict() -> None:
-    """Test normal use case."""
-
-    @dc.dataclass(frozen=True)
-    class Config:
-        FOO: dict[Literal["greeting"], Literal["hello", "hi", "howdy"]]
-
-    os.environ["FOO"] = "greeting:hello"
-    config = from_environment_as_dataclass(Config)
-    assert config.FOO == {"greeting": "hello"}
-
-
-@pytest.mark.usefixtures("isolated_env")
 def test_100_error__missing_required() -> None:
     """Test error use case."""
 
@@ -844,6 +831,27 @@ def test_110_error__any() -> None:
     os.environ["FOO"] = "foo bar baz"
     with pytest.raises(ValueError):
         from_environment_as_dataclass(Config)
+
+
+@pytest.mark.usefixtures("isolated_env")
+def test_111__literal_dict() -> None:
+    """Test normal use case."""
+
+    # NOT YET SUPPORTED, MAYBE SOMEDAY
+
+    @dc.dataclass(frozen=True)
+    class Config:
+        FOO: dict[Literal["greeting"], Literal["hello", "hi", "howdy"]]
+
+    os.environ["FOO"] = "greeting:hello"
+    with pytest.raises(ValueError) as cm:
+        from_environment_as_dataclass(Config)
+    assert str(cm.value).startswith(
+        "'typing.List[typing.Dict[str, int]]' is not a "
+        "supported type: field='FOO' (typehints "
+        "must resolve to 'type' within 1 nesting, or "
+        "2 if using 'Final', 'Optional', or a None-'Union' pairing)"
+    )
 
 
 @pytest.mark.usefixtures("isolated_env")

--- a/tests/enviro_test.py
+++ b/tests/enviro_test.py
@@ -766,7 +766,7 @@ def test_105_error__overly_nested_type_alias() -> None:
     os.environ["FOO"] = "doesn't matter, this won't get read before error"
     with pytest.raises(ValueError) as cm:
         from_environment_as_dataclass(Config)
-    assert str(cm.value) == (
+    assert str(cm.value).startswith(
         "'typing.List[typing.Dict[str, int]]' is not a "
         "supported type: field='FOO' (typehints "
         "must resolve to 'type' within 1 nesting, or "

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -499,7 +499,7 @@ def _from_environment_as_dataclass(
             else:
                 raise ValueError(
                     f"'{field.type}'-indicated value is not a legal value: "
-                    f"var='{field.name}' value='{env_val}' (options: {e.typ_args})"
+                    f"var='{field.name}' value='{env_val}' -- choices: {e.typ_args})"
                 )
         else:
             # cast value to type

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -180,16 +180,16 @@ class TypeCaster:
                 f"'{collection_sep}' & '{dict_kv_joiner}'"
             )
 
-    def typecast_for_dataclass(
+    def typecast(
         self,
-        env_val: str,
+        val: str,
         typ: type,
         arg_typs: Optional[Tuple[type, ...]],
     ) -> Any:
         """Collect the typecast value."""
 
         if typ == list:
-            _list = env_val.split(self.collection_sep)
+            _list = val.split(self.collection_sep)
             if arg_typs:
                 return [arg_typs[0](x) for x in _list]
             return _list
@@ -197,29 +197,29 @@ class TypeCaster:
         elif typ == dict:
             _dict = {
                 x.split(self.dict_kv_joiner)[0]: x.split(self.dict_kv_joiner)[1]
-                for x in env_val.split(self.collection_sep)
+                for x in val.split(self.collection_sep)
             }
             if arg_typs:
                 return {arg_typs[0](k): arg_typs[1](v) for k, v in _dict.items()}
             return _dict
 
         elif typ == set:
-            _set = set(env_val.split(self.collection_sep))
+            _set = set(val.split(self.collection_sep))
             if arg_typs:
                 return {arg_typs[0](x) for x in _set}
             return _set
 
         elif typ == frozenset:
-            _frozenset = frozenset(env_val.split(self.collection_sep))
+            _frozenset = frozenset(val.split(self.collection_sep))
             if arg_typs:
                 return {arg_typs[0](x) for x in _frozenset}
             return _frozenset
 
         elif typ == bool:
-            return strtobool(env_val)
+            return strtobool(val)
 
         else:
-            return typ(env_val)
+            return typ(val)
 
 
 def from_environment_as_dataclass(
@@ -504,9 +504,7 @@ def _from_environment_as_dataclass(
         else:
             # cast value to type
             try:
-                env_var_attrs[field.name] = typecaster.typecast_for_dataclass(
-                    env_val, typ, arg_typs
-                )
+                env_var_attrs[field.name] = typecaster.typecast(env_val, typ, arg_typs)
             except ValueError as e:
                 raise ValueError(
                     f"'{field.type}'-indicated value is not a legal value: "

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -387,7 +387,7 @@ class TypeHintDeconstructor:
                 ")"
             )
         elif typ_origin == Literal or (
-            typ_args and any(isinstance(t, type(Literal["foo"])) for t in typ_args)
+            typ_args and any(t == Literal for t in typ_args)
         ):
             raise LiteralTypeException(typ_origin=typ_origin, typ_args=typ_args)
         # fall-through: okay

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -499,7 +499,7 @@ def _from_environment_as_dataclass(
             else:
                 raise ValueError(
                     f"'{field.type}'-indicated value is not a legal value: "
-                    f"var='{field.name}' value='{env_val}' -- choices: {e.typ_args})"
+                    f"var='{field.name}' value='{env_val}' -- choices: {arg_typs})"
                 )
 
         # cast value to type

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -386,7 +386,9 @@ class TypeHintDeconstructor:
                 f"'int | None', or 'None | str'"
                 ")"
             )
-        elif typ_origin == Literal or any(t == Literal for t in typ_args):
+        elif typ_origin == Literal or (
+            typ_args and any(t == Literal for t in typ_args)
+        ):
             raise LiteralTypeException(typ_origin=typ_origin, typ_args=typ_args)
         # fall-through: okay
 

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -18,7 +18,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    _LiteralGenericAlias,
+    _LiteralSpecialForm,
     _SpecialForm,
     cast,
 )
@@ -385,7 +385,7 @@ class TypeHintDeconstructor:
     def deconstruct_from_dc_field(
         field: dataclasses.Field,
     ) -> Tuple[
-        type | _LiteralGenericAlias, Optional[Tuple[type | _LiteralGenericAlias, ...]]
+        type | _LiteralSpecialForm, Optional[Tuple[type | _LiteralSpecialForm, ...]]
     ]:
         """Take a type hint and return its type and its arguments' types."""
         TypeHintDeconstructor._check_invalid_typehints(field.type, tuple(), field)
@@ -435,10 +435,10 @@ class TypeHintDeconstructor:
             f"or 2 if using 'Final', 'Optional', or a None-'Union' pairing) "
             f" -- ({typ_origin=}, {typ_args=})"
         )
-        if not isinstance(typ_origin, type | _LiteralGenericAlias):
+        if not isinstance(typ_origin, type | _LiteralSpecialForm):
             raise ValueError(too_nested_error_msg)
         if typ_args and not (
-            all(isinstance(x, type | _LiteralGenericAlias) for x in typ_args)
+            all(isinstance(x, type | _LiteralSpecialForm) for x in typ_args)
         ):
             raise ValueError(too_nested_error_msg)
 

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -18,7 +18,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    _LiteralSpecialForm,
     _SpecialForm,
     cast,
 )
@@ -384,9 +383,7 @@ class TypeHintDeconstructor:
     @staticmethod
     def deconstruct_from_dc_field(
         field: dataclasses.Field,
-    ) -> Tuple[
-        type | _LiteralSpecialForm, Optional[Tuple[type | _LiteralSpecialForm, ...]]
-    ]:
+    ) -> Tuple[type | type(Literal), Optional[Tuple[type | type(Literal), ...]]]:
         """Take a type hint and return its type and its arguments' types."""
         TypeHintDeconstructor._check_invalid_typehints(field.type, tuple(), field)
 
@@ -435,10 +432,10 @@ class TypeHintDeconstructor:
             f"or 2 if using 'Final', 'Optional', or a None-'Union' pairing) "
             f" -- ({typ_origin=}, {typ_args=})"
         )
-        if not isinstance(typ_origin, type | _LiteralSpecialForm):
+        if not isinstance(typ_origin, type | type(Literal)):
             raise ValueError(too_nested_error_msg)
         if typ_args and not (
-            all(isinstance(x, type | _LiteralSpecialForm) for x in typ_args)
+            all(isinstance(x, type | type(Literal)) for x in typ_args)
         ):
             raise ValueError(too_nested_error_msg)
 

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -397,7 +397,8 @@ def deconstruct_typehint(
     too_nested_error_msg = (
         f"'{field.type}' is not a supported type: field='{field.name}' "
         f"(typehints must resolve to 'type' within 1 nesting, "
-        f"or 2 if using 'Final', 'Optional', or a None-'Union' pairing)"
+        f"or 2 if using 'Final', 'Optional', or a None-'Union' pairing) "
+        f" -- ({typ_origin=}, {typ_args=})"
     )
     if not isinstance(typ_origin, type):
         raise ValueError(too_nested_error_msg)
@@ -487,6 +488,8 @@ def _from_environment_as_dataclass(
             logging.getLogger(),
             log_vars,
             prefix="(env)",
-            obfuscate_sensitive_substrings=obfuscate_log_vars if obfuscate_log_vars else True,
+            obfuscate_sensitive_substrings=(
+                obfuscate_log_vars if obfuscate_log_vars else True
+            ),
         )
     return env_vars_dc

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -392,7 +392,7 @@ class TypeHintDeconstructor:
     @staticmethod
     def deconstruct_from_dc_field(
         field: dataclasses.Field,
-    ) -> Tuple[type | Type[Literal], Optional[Tuple[type | Type[Literal], ...]]]:
+    ) -> Tuple[type | Type[Literal], Optional[Tuple[type | Type[Literal], ...]]]:  # type: ignore
         """Take a type hint and return its type and its arguments' types."""
         TypeHintDeconstructor._check_invalid_typehints(field.type, tuple(), field)
 

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -392,7 +392,7 @@ class TypeHintDeconstructor:
     @staticmethod
     def deconstruct_from_dc_field(
         field: dataclasses.Field,
-    ) -> Tuple[type | type(Literal), Optional[Tuple[type | type(Literal), ...]]]:
+    ) -> Tuple[type | Type[Literal], Optional[Tuple[type | Type[Literal], ...]]]:
         """Take a type hint and return its type and its arguments' types."""
         TypeHintDeconstructor._check_invalid_typehints(field.type, tuple(), field)
 

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -386,9 +386,7 @@ class TypeHintDeconstructor:
                 f"'int | None', or 'None | str'"
                 ")"
             )
-        elif typ_origin == Literal or (
-            typ_args and any(t == Literal for t in typ_args)
-        ):
+        elif typ_origin == Literal or any(t == Literal for t in typ_args):
             raise LiteralTypeException(typ_origin=typ_origin, typ_args=typ_args)
         # fall-through: okay
 

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -317,7 +317,8 @@ def from_environment_as_dataclass(
 class LiteralTypeException(Exception):
     """Raised when the type is the 'Literal' type, which is handled very differently."""
 
-    def __init__(self, typ_args: tuple):
+    def __init__(self, typ_origin: Any, typ_args: tuple):
+        self.type_origin = typ_origin
         self.typ_args = typ_args
 
 
@@ -385,8 +386,8 @@ class TypeHintDeconstructor:
                 f"'int | None', or 'None | str'"
                 ")"
             )
-        elif typ_origin == Literal:
-            raise LiteralTypeException(typ_args=typ_args)
+        elif typ_origin == Literal or any(t == Literal for t in typ_args):
+            raise LiteralTypeException(typ_origin=typ_origin, typ_args=typ_args)
         # fall-through: okay
 
     @staticmethod
@@ -498,14 +499,17 @@ def _from_environment_as_dataclass(
             typ, typ_args = TypeHintDeconstructor.deconstruct_from_dc_field(field)
         except LiteralTypeException as e:
             # test if value is in literal-type's list of choices
-            if env_val in e.typ_args:
-                env_var_attrs[field.name] = env_val
-                continue
-            else:
-                raise ValueError(
-                    f"'{field.type}'-indicated value is not a legal value: "
-                    f"var='{field.name}' value='{env_val}' -- choices: {e.typ_args})"
-                )
+            if e.type_origin == Literal:
+                if env_val in e.typ_args:
+                    env_var_attrs[field.name] = env_val
+                    continue
+                else:
+                    raise ValueError(
+                        f"'{field.type}'-indicated value is not a legal value: "
+                        f"var='{field.name}' value='{env_val}' -- choices: {e.typ_args})"
+                    )
+            elif any(t == Literal for t in e.typ_args):
+                raise ValueError("HERE") from e
 
         # cast value to type
         try:

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -392,7 +392,7 @@ class TypeHintDeconstructor:
     @staticmethod
     def deconstruct_from_dc_field(
         field: dataclasses.Field,
-    ) -> Tuple[type | Type[Literal], Optional[Tuple[type | Type[Literal], ...]]]:  # type: ignore
+    ) -> Tuple[type, Optional[Tuple[type, ...]]]:
         """Take a type hint and return its type and its arguments' types."""
         TypeHintDeconstructor._check_invalid_typehints(field.type, tuple(), field)
 

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -387,7 +387,7 @@ class TypeHintDeconstructor:
                 ")"
             )
         elif typ_origin == Literal or (
-            typ_args and any(t == Literal for t in typ_args)
+            typ_args and any(isinstance(t, type(Literal["foo"])) for t in typ_args)
         ):
             raise LiteralTypeException(typ_origin=typ_origin, typ_args=typ_args)
         # fall-through: okay


### PR DESCRIPTION
Ex: ```
Literal[
    "CRITICAL",
    "ERROR",
    "WARNING",
    "INFO",
    "DEBUG",
    "critical",
    "error",
    "warning",
    "info",
    "debug",
]```
 OR `logging_tools.LoggerLevel`