### PR TITLE
Simplify `semantic_version` Import Restrictions

### DIFF
--- a/wipac_dev_tools/semver_parser_tools.py
+++ b/wipac_dev_tools/semver_parser_tools.py
@@ -9,14 +9,6 @@ from typing import List, Tuple
 import requests
 from dateutil import parser
 
-# 'semver' imports
-try:
-    import semantic_version  # type: ignore[import-untyped]
-except (ImportError, ModuleNotFoundError) as _exc:
-    raise ImportError(
-        "the 'semver' option must be installed in order to use 'semver_parser_tools'"
-    ) from _exc
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -117,13 +109,24 @@ def list_all_majmin_versions(
         major: 3  semver_range: >=3.5.1         max_minor: 8        -> [3.6, 3.7, 3.8]
         major: 3  semver_range: >=3,<3.6,!=3.3  max_minor: default  -> [3.0, 3.1, 3.2, 3.4, 3.5]
     """
+
+    # import parsing package -- only used by this function
+    try:
+        import semantic_version  # type: ignore[import-untyped]
+    except (ImportError, ModuleNotFoundError) as _exc:
+        raise ImportError(
+            "the 'semver' option must be installed in order to use 'semver_parser_tools'"
+        ) from _exc
+
+    # parse
     spec = semantic_version.SimpleSpec(semver_range.replace(" ", ""))
 
+    # iterate
     filtered = spec.filter(
         semantic_version.Version(f"{major}.{i}.0") for i in range(max_minor + 1)
     )
-
     all_of_em = [(int(v.major), int(v.minor)) for v in filtered]
+
     LOGGER.info(f"matching major-minor versions: {all_of_em}")
     return all_of_em
 


### PR DESCRIPTION
Since #142, `semver_parser_tools.py` is used by other functions in the package. The import restriction on `semantic_version` dependency (only available by the `semver` install extra) prevented otherwise functional code. This restriction has been moved to inside the one function that uses it.