### PR TITLE
`mongo_jsonschema_tools.py`: QOL Updates [minor]

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -26,7 +26,7 @@ jobs:
 
   lint:
     needs: [ py-versions ]
-    uses: WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@v1.21
+    uses: WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@v1.26
     with:
       py-matrix-json: ${{ needs.py-versions.outputs.matrix }}
       max-complexity: 10  # ideal is ~10-15
@@ -172,7 +172,7 @@ jobs:
       py-dependencies,
       tests,
     ]
-    uses: WIPACrepo/wipac-dev-workflows/.github/workflows/tag-and-release.yml@v1.20
+    uses: WIPACrepo/wipac-dev-workflows/.github/workflows/tag-and-release.yml@v1.26
     permissions: # for GITHUB_TOKEN
       contents: write
     with:

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -95,7 +95,6 @@ jobs:
           PYTEST_INFO_JSON='[
             "vanilla:[tests]",
             "prometheus_tools_test.py:[tests,prometheus]",
-            "mongo_jsonschema_tools_test.py:[tests,motor_soon_deprecated,jsonschema]",
             "mongo_jsonschema_tools_test.py:[tests,mongo,jsonschema]"
           ]'
           

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,6 @@ semver = [
 mongo = [
     'pymongo',
 ]
-motor_soon_deprecated = [
-    'motor',
-]
 jsonschema = [
     'jsonschema',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ tests = [
 ]
 mypy = [
     'jsonschema',
-    'motor',
     'prometheus-client',
     'pymongo',
     'pytest',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-"""Setup."""
-
-
-from setuptools import setup  # type: ignore[import]  # mypy error in GH Action
-
-setup()

--- a/tests/mongo_jsonschema_tools_test.py
+++ b/tests/mongo_jsonschema_tools_test.py
@@ -10,7 +10,7 @@ from wipac_dev_tools.mongo_jsonschema_tools import (
     DocumentNotFoundException,
     IllegalDotsNotationActionException,
     MongoJSONSchemaValidatedCollection,
-    _IS_MOTOR_IMPORTED,
+    _JSONSchemaTransformer,
     _convert_mongo_to_jsonschema,
 )
 
@@ -19,21 +19,12 @@ ValidationError = jsonschema.exceptions.ValidationError
 
 def make_coll(schema: dict) -> MongoJSONSchemaValidatedCollection:
     """Create a MongoJSONSchemaValidatedCollection instance with a mocked backend."""
-
-    # FUTURE DEV: once motor, is deprecated, we can remove this
-    if _IS_MOTOR_IMPORTED:
-        coll_classname = "motor.motor_asyncio.AsyncIOMotorCollection"
-    else:
-        coll_classname = "pymongo.asynchronous.collection.AsyncCollection"
-
-    with patch(coll_classname):
-        coll = MongoJSONSchemaValidatedCollection(
+    with patch("pymongo.asynchronous.collection.AsyncCollection"):
+        return MongoJSONSchemaValidatedCollection(
             collection=AsyncMock(),
             collection_jsonschema_spec=schema,
             parent_logger=logging.getLogger("test_logger"),
         )
-        coll._collection_backend = coll_classname.rsplit(".", maxsplit=1)[1]
-        return coll
 
 
 @pytest.fixture
@@ -90,8 +81,9 @@ def team_schema():
 def test_0000__convert_no_dots_no_partial_returns_as_is(bio_schema):
     """Test conversion passes through doc and schema as-is if no dotted keys."""
     doc = {"name": "Charlie", "age": 28}
+    transformer = _JSONSchemaTransformer(bio_schema)
     out_doc, out_schema = _convert_mongo_to_jsonschema(
-        doc, bio_schema, allow_partial_update=False
+        doc, transformer, allow_partial_update=False
     )
     assert out_doc == doc
     assert out_schema == bio_schema
@@ -100,15 +92,17 @@ def test_0000__convert_no_dots_no_partial_returns_as_is(bio_schema):
 def test_0001__convert_with_dots_no_partial_raises(bio_schema):
     """Test conversion with dotted keys and no partial update raises error."""
     doc = {"address.city": "Springfield"}
+    transformer = _JSONSchemaTransformer(bio_schema)
     with pytest.raises(IllegalDotsNotationActionException):
-        _convert_mongo_to_jsonschema(doc, bio_schema, allow_partial_update=False)
+        _convert_mongo_to_jsonschema(doc, transformer, allow_partial_update=False)
 
 
 def test_0002__convert_with_dots_and_partial_succeeds(bio_schema):
     """Test conversion with dotted keys and partial update flattens and validates."""
     doc = {"address.city": "Metropolis"}
+    transformer = _JSONSchemaTransformer(bio_schema)
     out_doc, out_schema = _convert_mongo_to_jsonschema(
-        doc, bio_schema, allow_partial_update=True
+        doc, transformer, allow_partial_update=True
     )
     assert out_doc == {"address": {"city": "Metropolis"}}
     assert out_schema["required"] == []
@@ -127,8 +121,9 @@ def test_0003__convert_with_additional_properties_and_partial():
         "additionalProperties": True,
     }
     doc = {"custom.field": "yes"}
+    transformer = _JSONSchemaTransformer(schema)
     out_doc, out_schema = _convert_mongo_to_jsonschema(
-        doc, schema, allow_partial_update=True
+        doc, transformer, allow_partial_update=True
     )
     assert out_doc == {"custom": {"field": "yes"}}
     assert out_schema["required"] == []
@@ -148,8 +143,9 @@ def test_0004__convert_with_nested_additional_properties_blocked__but_ok():
         "required": ["meta"],
     }
     doc = {"meta.extra": "boom"}
+    transformer = _JSONSchemaTransformer(schema)
     out_doc, out_schema = _convert_mongo_to_jsonschema(
-        doc, schema, allow_partial_update=True
+        doc, transformer, allow_partial_update=True
     )
     assert out_doc == {"meta": {"extra": "boom"}}
     assert out_schema["properties"]["meta"]["additionalProperties"] is False
@@ -160,6 +156,33 @@ def test_0004__convert_with_nested_additional_properties_blocked__but_ok():
     # see...
     with pytest.raises(jsonschema.exceptions.ValidationError):
         jsonschema.validate(out_doc, out_schema)
+
+
+########################################################################################
+# _JSONSchemaTransformer caching & defensive copy
+
+
+def test_0050__transformer_caches_partial_schemas(bio_schema):
+    """Test that repeated unrequire calls with same dotted-key set hit the cache."""
+    transformer = _JSONSchemaTransformer(bio_schema)
+    transformer._unrequire_key_ancestors.cache_clear()
+
+    # different values, same dotted-key set -> 1 miss, 1 hit
+    transformer.unrequire_key_ancestors({"address.city": "A"})
+    transformer.unrequire_key_ancestors({"address.city": "B"})
+
+    info = transformer._unrequire_key_ancestors.cache_info()
+    assert info.misses == 1
+    assert info.hits == 1
+
+
+def test_0051__transformer_deep_copies_input_schema(bio_schema):
+    """Test that mutating the input schema after construction doesn't poison the transformer."""
+    transformer = _JSONSchemaTransformer(bio_schema)
+    bio_schema["required"] = ["mutated"]  # external mutation
+
+    # transformer's copy is unaffected
+    assert transformer.full_schema["required"] == ["name", "age"]
 
 
 ########################################################################################
@@ -437,7 +460,7 @@ def test_0204__validate_mongo_update__push_baseball_invalid(team_schema):
 
 
 @pytest.mark.asyncio
-async def test_1000__insert_one_calls_validate_and_motor(
+async def test_1000__insert_one_calls_validate_and_collection(
     bio_coll: MongoJSONSchemaValidatedCollection,
 ):
     """Test insert_one calls validation and insert_one."""
@@ -458,7 +481,7 @@ async def test_1000__insert_one_calls_validate_and_motor(
 
 
 @pytest.mark.asyncio
-async def test_1100__insert_many_calls_validate_and_motor(
+async def test_1100__insert_many_calls_validate_and_collection(
     bio_coll: MongoJSONSchemaValidatedCollection,
 ):
     """Test insert_many calls validation on each doc."""
@@ -513,7 +536,7 @@ async def test_1201__find_one_not_found_raises(
 
 
 @pytest.mark.asyncio
-async def test_1300__find_one_and_update_calls_validate_and_motor(
+async def test_1300__find_one_and_update_calls_validate_and_collection(
     bio_coll: MongoJSONSchemaValidatedCollection,
 ):
     """Test find_one_and_update calls validation and returns updated doc."""
@@ -555,7 +578,7 @@ async def test_1301__find_one_and_update_not_found_raises(
 
 
 @pytest.mark.asyncio
-async def test_1400__update_many_calls_validate_and_motor(
+async def test_1400__update_many_calls_validate_and_collection(
     bio_coll: MongoJSONSchemaValidatedCollection,
 ):
     """Test update_many calls validation and returns modified count."""
@@ -626,21 +649,11 @@ async def test_1600__aggregate_removes_id(
         for doc in docs:
             yield doc
 
-    if bio_coll._collection_backend == "AsyncIOMotorCollection":
-        # Motor-style: aggregate() returns an async iterator / cursor directly
-        bio_coll._collection.aggregate = (  # type: ignore[method-assign]
-            lambda *_args, **_kwargs: async_gen()
-        )
-    elif bio_coll._collection_backend == "AsyncCollection":
-        # PyMongo async-style: aggregate() is a coroutine that resolves to an async iterator
-        async def aggregate_coro(*_args, **_kwargs):
-            return async_gen()
+    # PyMongo async-style: aggregate() is a coroutine that resolves to an async iterator
+    async def aggregate_coro(*_args, **_kwargs):
+        return async_gen()
 
-        bio_coll._collection.aggregate = aggregate_coro  # type: ignore[method-assign]
-    else:
-        raise AssertionError(
-            f"Unexpected backend in test: {bio_coll._collection_backend!r}"
-        )
+    bio_coll._collection.aggregate = aggregate_coro  # type: ignore[method-assign]
 
     # check calls & result
     results = [doc async for doc in bio_coll.aggregate([{"$match": {}}])]
@@ -662,18 +675,8 @@ async def test_1700__aggregate_one_returns_first_doc(
         for doc in docs:
             yield doc
 
-    # Choose a mock shape that matches the backend semantics
-    if bio_coll._collection_backend == "AsyncIOMotorCollection":
-        # Motor-style: aggregate returns an async iterator directly (no await)
-        agg_mock = MagicMock(return_value=async_gen())
-    elif bio_coll._collection_backend == "AsyncCollection":
-        # PyMongo async-style: aggregate is awaited and returns the async iterator
-        agg_mock = AsyncMock(return_value=async_gen())
-    else:
-        raise AssertionError(
-            f"Unexpected backend in test: {bio_coll._collection_backend!r}"
-        )
-
+    # PyMongo async-style: aggregate is awaited and returns the async iterator
+    agg_mock = AsyncMock(return_value=async_gen())
     bio_coll._collection.aggregate = agg_mock  # type: ignore[method-assign]
 
     pipeline = [{"$match": {}}]  # type: ignore[var-annotated]
@@ -694,17 +697,8 @@ async def test_1701__aggregate_one_not_found_raises(
         for _ in []:  # hack for empty async iter
             yield
 
-    if bio_coll._collection_backend == "AsyncIOMotorCollection":
-        # Motor-style: aggregate returns an async iterator directly (no await)
-        agg_mock = MagicMock(return_value=async_gen())
-    elif bio_coll._collection_backend == "AsyncCollection":
-        # PyMongo async-style: aggregate is awaited and returns the async iterator
-        agg_mock = AsyncMock(return_value=async_gen())
-    else:
-        raise AssertionError(
-            f"Unexpected backend in test: {bio_coll._collection_backend!r}"
-        )
-
+    # PyMongo async-style: aggregate is awaited and returns the async iterator
+    agg_mock = AsyncMock(return_value=async_gen())
     bio_coll._collection.aggregate = agg_mock  # type: ignore[method-assign]
 
     pipeline = [{"$match": {"val": "none"}}]

--- a/tests/mongo_jsonschema_tools_test.py
+++ b/tests/mongo_jsonschema_tools_test.py
@@ -472,7 +472,9 @@ async def test_1000__insert_one_calls_validate_and_collection(
 
     # check calls & result
     bio_coll._validate.assert_called_once_with(doc)  # ty:ignore[unresolved-attribute]
-    bio_coll._collection.insert_one.assert_called_once_with(doc)
+    bio_coll._collection.insert_one.assert_called_once_with(  # ty:ignore[unresolved-attribute]
+        doc
+    )
     assert result == doc
 
 
@@ -497,7 +499,9 @@ async def test_1100__insert_many_calls_validate_and_collection(
     # check calls & result
     assert result == docs
     assert bio_coll._validate.call_count == 2  # ty:ignore[unresolved-attribute]
-    bio_coll._collection.insert_many.assert_called_once_with(docs)
+    bio_coll._collection.insert_many.assert_called_once_with(  # ty:ignore[unresolved-attribute]
+        docs
+    )
 
 
 ########################################################################################
@@ -516,7 +520,9 @@ async def test_1200__find_one_removes_id_and_returns(
     result = await bio_coll.find_one({"name": "Alice"})
 
     # check calls & result
-    bio_coll._collection.find_one.assert_called_once_with({"name": "Alice"})
+    bio_coll._collection.find_one.assert_called_once_with(  # ty:ignore[unresolved-attribute]
+        {"name": "Alice"}
+    )
     assert result == {"name": "Alice", "age": 30}
 
 
@@ -551,10 +557,10 @@ async def test_1300__find_one_and_update_calls_validate_and_collection(
     bio_coll._validate_mongo_update.assert_called_once_with(  # ty:ignore[unresolved-attribute]
         update
     )
-    bio_coll._collection.find_one_and_update.assert_called_once_with(
+    bio_coll._collection.find_one_and_update.assert_called_once_with(  # ty:ignore[unresolved-attribute]
         {"name": "Alice"},
         update,
-        return_document=bio_coll._collection.find_one_and_update.call_args.kwargs[
+        return_document=bio_coll._collection.find_one_and_update.call_args.kwargs[  # ty:ignore[unresolved-attribute]
             "return_document"
         ],
     )
@@ -592,7 +598,7 @@ async def test_1400__update_many_calls_validate_and_collection(
     bio_coll._validate_mongo_update.assert_called_once_with(  # ty:ignore[unresolved-attribute]
         {"$set": {"age": 40}}
     )
-    bio_coll._collection.update_many.assert_called_once_with(
+    bio_coll._collection.update_many.assert_called_once_with(  # ty:ignore[unresolved-attribute]
         {"active": True}, {"$set": {"age": 40}}
     )
     assert count == 3

--- a/tests/mongo_jsonschema_tools_test.py
+++ b/tests/mongo_jsonschema_tools_test.py
@@ -465,8 +465,8 @@ async def test_1000__insert_one_calls_validate_and_collection(
 ):
     """Test insert_one calls validation and insert_one."""
     doc = {"name": "Alice", "age": 30}
-    bio_coll._validate = MagicMock()  # type: ignore[method-assign]
-    bio_coll._collection.insert_one = AsyncMock()  # type: ignore[method-assign]
+    bio_coll._validate = MagicMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
+    bio_coll._collection.insert_one = AsyncMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     result = await bio_coll.insert_one(doc.copy())
 
@@ -489,8 +489,8 @@ async def test_1100__insert_many_calls_validate_and_collection(
         {"name": "Alice", "age": 30},
         {"name": "Bob", "age": 25},
     ]
-    bio_coll._validate = MagicMock()  # type: ignore[method-assign]
-    bio_coll._collection.insert_many = AsyncMock()  # type: ignore[method-assign]
+    bio_coll._validate = MagicMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
+    bio_coll._collection.insert_many = AsyncMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     result = await bio_coll.insert_many([doc.copy() for doc in docs])
 
@@ -509,7 +509,7 @@ async def test_1200__find_one_removes_id_and_returns(
     bio_coll: MongoJSONSchemaValidatedCollection,
 ):
     """Test find_one removes _id and returns result."""
-    bio_coll._collection.find_one = AsyncMock(  # type: ignore[method-assign]
+    bio_coll._collection.find_one = AsyncMock(  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
         return_value={"_id": "id", "name": "Alice", "age": 30}
     )
 
@@ -525,7 +525,7 @@ async def test_1201__find_one_not_found_raises(
     bio_coll: MongoJSONSchemaValidatedCollection,
 ):
     """Test find_one raises DocumentNotFoundException when no document found."""
-    bio_coll._collection.find_one = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    bio_coll._collection.find_one = AsyncMock(return_value=None)  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     with pytest.raises(DocumentNotFoundException):
         await bio_coll.find_one({"name": "Missing"})
@@ -542,8 +542,8 @@ async def test_1300__find_one_and_update_calls_validate_and_collection(
     """Test find_one_and_update calls validation and returns updated doc."""
     update = {"$set": {"age": 35}}
     result_doc = {"_id": "x", "name": "Updated", "age": 35}
-    bio_coll._validate_mongo_update = MagicMock()  # type: ignore[method-assign]
-    bio_coll._collection.find_one_and_update = AsyncMock(return_value=result_doc)  # type: ignore[method-assign]
+    bio_coll._validate_mongo_update = MagicMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
+    bio_coll._collection.find_one_and_update = AsyncMock(return_value=result_doc)  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     result = await bio_coll.find_one_and_update({"name": "Alice"}, update)
 
@@ -566,8 +566,8 @@ async def test_1301__find_one_and_update_not_found_raises(
     bio_coll: MongoJSONSchemaValidatedCollection,
 ):
     """Test find_one_and_update raises DocumentNotFoundException if not found."""
-    bio_coll._validate_mongo_update = MagicMock()  # type: ignore[method-assign]
-    bio_coll._collection.find_one_and_update = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    bio_coll._validate_mongo_update = MagicMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
+    bio_coll._collection.find_one_and_update = AsyncMock(return_value=None)  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     with pytest.raises(DocumentNotFoundException):
         await bio_coll.find_one_and_update({"name": "Missing"}, {"$set": {"age": 35}})
@@ -583,8 +583,8 @@ async def test_1400__update_many_calls_validate_and_collection(
 ):
     """Test update_many calls validation and returns modified count."""
     mock_res = MagicMock(matched_count=1, modified_count=3)
-    bio_coll._validate_mongo_update = MagicMock()  # type: ignore[method-assign]
-    bio_coll._collection.update_many = AsyncMock(return_value=mock_res)  # type: ignore[method-assign]
+    bio_coll._validate_mongo_update = MagicMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
+    bio_coll._collection.update_many = AsyncMock(return_value=mock_res)  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     count = await bio_coll.update_many({"active": True}, {"$set": {"age": 40}})
 
@@ -603,8 +603,8 @@ async def test_1401__update_many_not_found_raises(
     bio_coll: MongoJSONSchemaValidatedCollection,
 ):
     """Test update_many raises DocumentNotFoundException if no documents matched."""
-    bio_coll._validate_mongo_update = MagicMock()  # type: ignore[method-assign]
-    bio_coll._collection.update_many = AsyncMock(  # type: ignore[method-assign]
+    bio_coll._validate_mongo_update = MagicMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
+    bio_coll._collection.update_many = AsyncMock(  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
         return_value=MagicMock(matched_count=0)
     )
 
@@ -627,7 +627,7 @@ async def test_1500__find_all_removes_id(
         for doc in docs:
             yield doc
 
-    bio_coll._collection.find = lambda *_args, **_kwargs: async_gen()  # type: ignore[method-assign]
+    bio_coll._collection.find = lambda *_args, **_kwargs: async_gen()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     # check calls & result
     results = [doc async for doc in bio_coll.find_all({}, ["name"])]
@@ -653,7 +653,7 @@ async def test_1600__aggregate_removes_id(
     async def aggregate_coro(*_args, **_kwargs):
         return async_gen()
 
-    bio_coll._collection.aggregate = aggregate_coro  # type: ignore[method-assign]
+    bio_coll._collection.aggregate = aggregate_coro  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     # check calls & result
     results = [doc async for doc in bio_coll.aggregate([{"$match": {}}])]
@@ -677,7 +677,7 @@ async def test_1700__aggregate_one_returns_first_doc(
 
     # PyMongo async-style: aggregate is awaited and returns the async iterator
     agg_mock = AsyncMock(return_value=async_gen())
-    bio_coll._collection.aggregate = agg_mock  # type: ignore[method-assign]
+    bio_coll._collection.aggregate = agg_mock  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     pipeline = [{"$match": {}}]  # type: ignore[var-annotated]
     result = await bio_coll.aggregate_one(pipeline.copy())
@@ -699,7 +699,7 @@ async def test_1701__aggregate_one_not_found_raises(
 
     # PyMongo async-style: aggregate is awaited and returns the async iterator
     agg_mock = AsyncMock(return_value=async_gen())
-    bio_coll._collection.aggregate = agg_mock  # type: ignore[method-assign]
+    bio_coll._collection.aggregate = agg_mock  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
     pipeline = [{"$match": {"val": "none"}}]
     with pytest.raises(DocumentNotFoundException):

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -29,9 +29,9 @@ from . import logging_tools
 from .strtobool import strtobool
 
 try:
-    from typing import _GenericAlias as GenericAlias  # type: ignore[attr-defined]
+    from typing import _GenericAlias as GenericAlias  # type: ignore[attr-defined]  # ty: ignore[unresolved-import]
 except ImportError:
-    from typing import GenericAlias  # type: ignore[attr-defined]
+    from typing import GenericAlias  # type: ignore[attr-defined]  # ty: ignore[unresolved-import]
 
 # fmt: off
 if TYPE_CHECKING:  # _typeshed only exists at runtime

--- a/wipac_dev_tools/enviro_tools.py
+++ b/wipac_dev_tools/enviro_tools.py
@@ -29,9 +29,9 @@ from . import logging_tools
 from .strtobool import strtobool
 
 try:
-    from typing import _GenericAlias as GenericAlias  # type: ignore[attr-defined]  # ty: ignore[unresolved-import]
+    from typing import _GenericAlias as GenericAlias  # type: ignore[attr-defined]  # ty: ignore[unresolved-import]  # noqa: I001
 except ImportError:
-    from typing import GenericAlias  # type: ignore[attr-defined]  # ty: ignore[unresolved-import]
+    from typing import GenericAlias  # type: ignore[attr-defined]  # ty: ignore[unresolved-import]  # noqa: I001
 
 # fmt: off
 if TYPE_CHECKING:  # _typeshed only exists at runtime

--- a/wipac_dev_tools/logging_tools.py
+++ b/wipac_dev_tools/logging_tools.py
@@ -50,8 +50,6 @@ def get_logger_fn(
     logger: Union[None, str, logging.Logger], level: LoggerLevel
 ) -> Callable[[str], None]:
     """Get the logger function from `logger` and `level`."""
-    level = level.upper()  # type: ignore[assignment]
-
     if not logger:
         _logger = logging.getLogger()
     elif isinstance(logger, logging.Logger):
@@ -59,7 +57,7 @@ def get_logger_fn(
     else:
         _logger = logging.getLogger(logger)
 
-    if level not in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]:
+    if level.upper() not in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]:
         raise ValueError(f"Invalid logging level: {level}")
 
     return getattr(_logger, level.lower())  # ..., info, warning, critical, ...

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -39,6 +39,9 @@ except (ImportError, ModuleNotFoundError) as _exc:
     ) from _exc
 
 
+type JSON = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
+
+
 class DocumentNotFoundException(Exception):
     """Raised when document is not found for a particular query."""
 

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -323,7 +323,8 @@ class _JSONSchemaTransformer:
     """Holds a jsonschema spec plus a cached builder for partial-update variants."""
 
     def __init__(self, full_schema: JSON) -> None:
-        self.full_schema: Final[JSON] = full_schema
+        # deep-copy so external mutation can't corrupt cached schemas
+        self.full_schema: Final[JSON] = copy.deepcopy(full_schema)
 
     def unrequire_key_ancestors(self, mongo_dict: MongoDoc) -> JSON:
         """Return a deep-copy of `self.full_schema` with `required` cleared at the root
@@ -390,11 +391,14 @@ class _JSONSchemaTransformer:
             # leaf is the value slot, not a nested container to descend into
             *parent_keys, _leaf_key = dkey.split(".")
             for k in parent_keys:
+                # stop descending if we can't:
+                # - cursor falsy -> parent has no 'properties' (ex: only 'additionalProperties')
+                # - k not declared -> free-form region, jsonschema won't enforce `required` here anyway
+                if not schema_props_cursor or k not in schema_props_cursor:
+                    break
                 # mark nested object 'required' as none
-                if schema_props_cursor:
-                    # ^^^ falsy when not "in" a properties obj, ex: parent only has 'additionalProperties'
-                    schema_props_cursor[k]["required"] = []
-                    schema_props_cursor = schema_props_cursor[k].get("properties")
+                schema_props_cursor[k]["required"] = []
+                schema_props_cursor = schema_props_cursor[k].get("properties")
         return schema
 
 
@@ -411,13 +415,12 @@ def _mongo_expand_dotted_keys(mongo_dict: MongoDoc) -> MongoDoc:
         out:
             {"book": {"title": "abc", "content": "def"}, "author": "ghi"}
     """
-
     # yes partial but no dots -> quick exit
     if not _has_dotted_keys(mongo_dict):
         return mongo_dict
 
     # https://stackoverflow.com/a/75734554/13156561 (looping logic)
-    out_dict = {}  # type: ignore
+    out_dict: MongoDoc = {}
     for og_key, value in mongo_dict.items():
         if "." not in og_key:
             out_dict[og_key] = value

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -79,18 +79,17 @@ class MongoJSONSchemaValidatedCollection:
 
     def _validate(
         self,
-        obj: MongoDoc,
+        mongo_obj: MongoDoc,
         allow_partial_update: bool = False,
     ) -> None:
         """Wrap `jsonschema.validate` with logic for mongo syntax."""
         try:
-            jsonschema.validate(
-                *_convert_mongo_to_jsonschema(
-                    obj,
-                    self._jsonschema_transformer,
-                    allow_partial_update,
-                )
+            json_obj, out_schema = _convert_mongo_to_jsonschema(
+                mongo_obj,
+                self._jsonschema_transformer,
+                allow_partial_update,
             )
+            jsonschema.validate(json_obj, out_schema)
         except Exception as e:
             self.logger.exception(e)
             if self.validation_exception_callback:

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -39,6 +39,7 @@ except (ImportError, ModuleNotFoundError) as _exc:
     ) from _exc
 
 JSON: TypeAlias = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
+MongoDoc: TypeAlias = dict[str, JSON]
 
 
 class DocumentNotFoundException(Exception):

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -4,7 +4,7 @@ import copy
 import functools
 import logging
 from collections.abc import AsyncIterator, Callable
-from typing import Any, Final, TypeAlias
+from typing import Any, Final, TypeAlias, cast
 
 # mongo imports
 try:
@@ -24,7 +24,7 @@ except (ImportError, ModuleNotFoundError) as _exc:
     ) from _exc
 
 JSON: TypeAlias = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
-MongoDoc: TypeAlias = dict[str, JSON]
+MongoDoc: TypeAlias = dict[str, Any]  # mongo can carry ObjectId, datetime, Binary, etc
 
 
 class DocumentNotFoundException(Exception):
@@ -106,13 +106,13 @@ class MongoJSONSchemaValidatedCollection:
         for operator in update:
             if operator == "$set":
                 self._validate(
-                    update[operator],  # type: ignore[arg-type]
+                    update[operator],
                     allow_partial_update=True,
                 )
             elif operator == "$push":
                 self._validate(
                     # validate each value as if it was the whole field's list -- other wise `str != [str]`
-                    {k: [v] for k, v in update[operator].items()},  # type: ignore[union-attr]
+                    {k: [v] for k, v in update[operator].items()},
                     allow_partial_update=True,
                 )
             # FUTURE: insert more operators here
@@ -293,7 +293,7 @@ def _convert_mongo_to_jsonschema(
     mongo_dict: MongoDoc,
     jsonschema_transformer: "_JSONSchemaTransformer",
     allow_partial_update: bool,
-) -> tuple[MongoDoc, JSON]:
+) -> tuple[MongoDoc, dict[str, Any]]:
     """Prepare a Mongo-style mapping and schema for JSON Schema validation.
 
     For partial updates, dotted keys are expanded into nested objects and the schema is
@@ -322,10 +322,13 @@ class _JSONSchemaTransformer:
     """Holds a jsonschema spec plus a cached builder for partial-update variants."""
 
     def __init__(self, full_schema: JSON) -> None:
-        # deep-copy so external mutation can't corrupt cached schemas
-        self.full_schema: Final[JSON] = copy.deepcopy(full_schema)
+        # deep-copy so external mutation can't corrupt cached schemas;
+        # narrow JSON->dict since jsonschema specs are always objects at the root
+        self.full_schema: Final[dict[str, Any]] = cast(
+            dict[str, Any], copy.deepcopy(full_schema)
+        )
 
-    def unrequire_key_ancestors(self, mongo_dict: MongoDoc) -> JSON:
+    def unrequire_key_ancestors(self, mongo_dict: MongoDoc) -> dict[str, Any]:
         """Return a deep-copy of `self.full_schema` with `required` cleared at the root
         and along each dotted key's parent chain. Treat as immutable.
 
@@ -376,17 +379,17 @@ class _JSONSchemaTransformer:
         )
 
     @functools.lru_cache(maxsize=64)
-    def _unrequire_key_ancestors(self, dotted_keys: frozenset[str]) -> JSON:
+    def _unrequire_key_ancestors(self, dotted_keys: frozenset[str]) -> dict[str, Any]:
         """Cached builder for `unrequire_key_ancestors()`.
 
         `frozenset` key makes cache hits order- and value-independent; `frozenset()`
         is the no-dotted-keys case.
         """
-        schema = copy.deepcopy(self.full_schema)  # expensive
-        schema["required"] = []  # type: ignore[index]
+        schema: dict[str, Any] = copy.deepcopy(self.full_schema)  # expensive
+        schema["required"] = []
         for dkey in dotted_keys:
             # (re)set schema cursor to root for each key
-            schema_props_cursor = schema["properties"]  # type: ignore[index]
+            schema_props_cursor: dict[str, Any] | None = schema["properties"]
             # leaf is the value slot, not a nested container to descend into
             *parent_keys, _leaf_key = dkey.split(".")
             for k in parent_keys:

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -38,8 +38,10 @@ except (ImportError, ModuleNotFoundError) as _exc:
         "the 'jsonschema' option must be installed in order to use 'mongo_jsonschema_tools'"
     ) from _exc
 
-
-type JSON = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
+if sys.version_info < (3, 12):
+    JSONType = dict[str, Any] | list | str | int | float | bool | None
+else:
+    type JSONType = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
 
 
 class DocumentNotFoundException(Exception):

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -4,7 +4,7 @@ import copy
 import logging
 import os
 import sys
-from typing import Any, AsyncIterator, Callable, Union
+from typing import Any, AsyncIterator, Callable, TypeAlias, Union
 
 # mongo imports
 _IS_MOTOR_IMPORTED = False
@@ -38,10 +38,7 @@ except (ImportError, ModuleNotFoundError) as _exc:
         "the 'jsonschema' option must be installed in order to use 'mongo_jsonschema_tools'"
     ) from _exc
 
-if sys.version_info < (3, 12):
-    JSON = dict[str, Any] | list | str | int | float | bool | None
-else:
-    type JSON = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
+JSON: TypeAlias = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
 
 
 class DocumentNotFoundException(Exception):

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -1,30 +1,15 @@
 """Tools for interfacing with mongodb using jsonschema validation."""
 
 import copy
+import functools
 import logging
-import os
-import sys
-from typing import Any, AsyncIterator, Callable, TypeAlias, Union
+from collections.abc import AsyncIterator, Callable
+from typing import Any, TypeAlias
 
 # mongo imports
-_IS_MOTOR_IMPORTED = False
 try:
     from pymongo import ReturnDocument
-
-    try:
-        # first, try motor — this will eventually be deprecated
-        # https://www.mongodb.com/docs/languages/python/pymongo-driver/current/reference/migration/
-        from motor.motor_asyncio import AsyncIOMotorCollection
-
-        _IS_MOTOR_IMPORTED = True
-        print(
-            "**DEPRECATION WARNING** 'motor' dependency will be deprecated May 14th, 2026",
-            file=sys.stderr,
-            flush=True,
-        )
-    except:  # noqa: E722
-        # if no motor, try pymongo — this is the long-term option
-        from pymongo.asynchronous.collection import AsyncCollection
+    from pymongo.asynchronous.collection import AsyncCollection
 except (ImportError, ModuleNotFoundError) as _exc:
     raise ImportError(
         "the 'mongo' option must be installed in order to use 'mongo_jsonschema_tools'"
@@ -69,29 +54,13 @@ class MongoJSONSchemaValidatedCollection:
 
     def __init__(
         self,
-        collection: "AsyncIOMotorCollection | AsyncCollection",
-        collection_jsonschema_spec: dict[str, Any],
-        parent_logger: Union[logging.Logger, None] = None,
-        validation_exception_callback: Union[
-            Callable[[Exception], Exception], None
-        ] = None,
+        collection: AsyncCollection,
+        collection_jsonschema_spec: JSON,
+        parent_logger: logging.Logger | None = None,
+        validation_exception_callback: Callable[[Exception], Exception] | None = None,
     ) -> None:
         self._collection = collection
         self._schema = collection_jsonschema_spec
-
-        # FUTURE DEV: once motor, is deprecated, we can remove this — this exists for test-patching
-        self._collection_backend = type(self._collection).__name__
-        # -- check that if 'motor' is installed, we're using it. Note: pymongo is always installed
-        if (
-            not os.getenv("CI")
-            and _IS_MOTOR_IMPORTED
-            and self._collection_backend != "AsyncIOMotorCollection"
-        ):
-            raise RuntimeError(
-                f"package 'motor' is installed, but 'MongoJSONSchemaValidatedCollection' "
-                f"object *not* initialized with 'AsyncIOMotorCollection' instance "
-                f"(attempted to use '{self._collection_backend}')"
-            )
 
         self.collection_name = collection.name
 
@@ -106,15 +75,32 @@ class MongoJSONSchemaValidatedCollection:
 
         self.validation_exception_callback = validation_exception_callback
 
+    @functools.cached_property
+    def _schema_cleared_root(self) -> JSON:
+        """Schema deep-copy with root `required` cleared; reused for the partial-update no-dots fast path.
+
+        Treat as immutable: callers must not mutate this value, or the cache will be
+        corrupted for the instance's lifetime. `jsonschema.validate` does not mutate
+        the schema it's given, so pass-through is safe.
+        """
+        cleared = copy.deepcopy(self._schema)
+        cleared["required"] = []  # type: ignore[index]
+        return cleared
+
     def _validate(
         self,
-        obj: dict,
+        obj: MongoDoc,
         allow_partial_update: bool = False,
     ) -> None:
         """Wrap `jsonschema.validate` with logic for mongo syntax."""
         try:
             jsonschema.validate(
-                *_convert_mongo_to_jsonschema(obj, self._schema, allow_partial_update)
+                *_convert_mongo_to_jsonschema(
+                    obj,
+                    self._schema,
+                    self._schema_cleared_root,
+                    allow_partial_update,
+                )
             )
         except Exception as e:
             self.logger.exception(e)
@@ -127,18 +113,18 @@ class MongoJSONSchemaValidatedCollection:
     # WRITES
     ####################################################################
 
-    def _validate_mongo_update(self, update: dict[str, Any]) -> None:
+    def _validate_mongo_update(self, update: MongoDoc) -> None:
         """Validate the data for each given mongo-syntax update operator."""
         for operator in update:
             if operator == "$set":
                 self._validate(
-                    update[operator],
+                    update[operator],  # type: ignore[arg-type]
                     allow_partial_update=True,
                 )
             elif operator == "$push":
                 self._validate(
                     # validate each value as if it was the whole field's list -- other wise `str != [str]`
-                    {k: [v] for k, v in update[operator].items()},
+                    {k: [v] for k, v in update[operator].items()},  # type: ignore[union-attr]
                     allow_partial_update=True,
                 )
             # FUTURE: insert more operators here
@@ -147,10 +133,10 @@ class MongoJSONSchemaValidatedCollection:
 
     async def insert_one(
         self,
-        doc: dict,
+        doc: MongoDoc,
         no_id: bool = True,
         **kwargs: Any,
-    ) -> dict:
+    ) -> MongoDoc:
         """Insert the doc (dict)."""
         self.logger.debug(f"inserting one: {doc}")
 
@@ -164,11 +150,11 @@ class MongoJSONSchemaValidatedCollection:
 
     async def find_one_and_update(
         self,
-        query: dict,
-        update: dict,
+        query: MongoDoc,
+        update: MongoDoc,
         no_id: bool = True,
         **kwargs: Any,
-    ) -> dict:
+    ) -> MongoDoc:
         """Update the doc and return updated doc."""
         self.logger.debug(f"update one with query: {query}")
 
@@ -189,10 +175,10 @@ class MongoJSONSchemaValidatedCollection:
 
     async def insert_many(
         self,
-        docs: list[dict],
+        docs: list[MongoDoc],
         no_id: bool = True,
         **kwargs: Any,
-    ) -> list[dict]:
+    ) -> list[MongoDoc]:
         """Insert multiple docs."""
         self.logger.debug(f"inserting many: {docs}")
 
@@ -209,8 +195,8 @@ class MongoJSONSchemaValidatedCollection:
 
     async def update_many(
         self,
-        query: dict,
-        update: dict,
+        query: MongoDoc,
+        update: MongoDoc,
         **kwargs: Any,
     ) -> int:
         """Update all matching docs."""
@@ -230,10 +216,10 @@ class MongoJSONSchemaValidatedCollection:
 
     async def find_one(
         self,
-        query: dict,
+        query: MongoDoc,
         no_id: bool = True,
         **kwargs: Any,
-    ) -> dict:
+    ) -> MongoDoc:
         """Find one matching the query."""
         self.logger.debug(f"finding one with query: {query}")
 
@@ -248,11 +234,11 @@ class MongoJSONSchemaValidatedCollection:
 
     async def find_all(
         self,
-        query: dict,
-        projection: list,
+        query: MongoDoc,
+        projection: list[str],
         no_id: bool = True,
         **kwargs: Any,
-    ) -> AsyncIterator[dict]:
+    ) -> AsyncIterator[MongoDoc]:
         """Find all matching the query."""
         self.logger.debug(f"finding with query: {query}")
 
@@ -268,30 +254,17 @@ class MongoJSONSchemaValidatedCollection:
 
     async def aggregate(
         self,
-        pipeline: list[dict],
+        pipeline: list[MongoDoc],
         no_id: bool = True,
         **kwargs: Any,
-    ) -> AsyncIterator[dict]:
+    ) -> AsyncIterator[MongoDoc]:
         """Find all matching the aggregate pipeline."""
         self.logger.debug(f"finding with aggregate pipeline: {pipeline}")
 
-        cursor: AsyncIterator[dict]  # typehint here, instantiate below
+        # PyMongo async's AsyncCollection.aggregate() returns a coroutine
+        # that must be awaited to obtain the async cursor.
+        cursor = await self._collection.aggregate(pipeline, **kwargs)
 
-        # FUTURE DEV: once motor, is deprecated, we can remove this complex logic
-        if self._collection_backend == "AsyncIOMotorCollection":
-            # Motor's AsyncIOMotorCollection.aggregate() returns an async cursor directly.
-            cursor = self._collection.aggregate(pipeline, **kwargs)  # type: ignore[assignment]
-        elif self._collection_backend == "AsyncCollection":
-            # PyMongo async's AsyncCollection.aggregate() returns a coroutine
-            # that must be awaited to obtain the async cursor.
-            cursor = await self._collection.aggregate(pipeline, **kwargs)  # type: ignore[misc]
-        else:
-            raise RuntimeError(
-                f"misconfigured MongoJSONSchemaValidatedCollection._collection: "
-                f"{self._collection_backend}"
-            )
-
-        # From here on, cursor is an async iterator
         i = 0
         async for doc in cursor:
             i += 1
@@ -304,9 +277,9 @@ class MongoJSONSchemaValidatedCollection:
 
     async def aggregate_one(
         self,
-        pipeline: list[dict],
+        pipeline: list[MongoDoc],
         **kwargs: Any,
-    ) -> dict:
+    ) -> MongoDoc:
         """Find one matching the aggregate pipeline.
 
         Appends `{"$limit": 1}` to pipeline.
@@ -323,27 +296,34 @@ class MongoJSONSchemaValidatedCollection:
 ########################################################################################
 
 
-def _has_dotted_keys(dicto: dict[str, Any]) -> bool:
+def _has_dotted_keys(dicto: MongoDoc) -> bool:
+    """Return True iff any top-level key in `dicto` contains a dot."""
     return any("." in k for k in dicto.keys())
 
 
 def _convert_mongo_to_jsonschema(
-    mongo_dict: dict,
-    full_jsonschema: dict,
+    mongo_dict: MongoDoc,
+    full_jsonschema: JSON,
+    schema_cleared_root: JSON,
     allow_partial_update: bool,
-) -> tuple[dict, dict]:
+) -> tuple[MongoDoc, JSON]:
     """Prepare a Mongo-style mapping and schema for JSON Schema validation.
 
     For partial updates, dotted keys are expanded into nested objects and the schema is
     adapted so touched object levels no longer require unspecified sibling fields. For
     non-partial validation, dotted keys raise `IllegalDotsNotationActionException`.
 
+    `schema_cleared_root` is the cached deep-copy of `full_jsonschema` with the root
+    `required` cleared, used for the partial-update no-dots fast path.
+
     Returns a tuple of `(normalized_object, schema_for_validation)`.
 
     NOTE: Does not support array/list dot-indexing
     """
     if allow_partial_update:
-        return _adapt_schema_for_partial_updating(mongo_dict, full_jsonschema)
+        return _adapt_schema_for_partial_updating(
+            mongo_dict, full_jsonschema, schema_cleared_root
+        )
     else:
         # no partial & yes dots -> error
         if _has_dotted_keys(mongo_dict):
@@ -354,14 +334,19 @@ def _convert_mongo_to_jsonschema(
 
 
 def _adapt_schema_for_partial_updating(
-    mongo_dict: dict,
-    full_jsonschema: dict,
-) -> tuple[dict, dict]:
+    mongo_dict: MongoDoc,
+    full_jsonschema: JSON,
+    schema_cleared_root: JSON,
+) -> tuple[MongoDoc, JSON]:
     """Expand dotted update keys and relax `required` constraints for partial validation.
 
-    Returns a nested object built from `mongo_dict` and a deep-copied schema whose root
-    `required` list is cleared. For dotted paths, traversed nested object schemas under
+    Returns a nested object built from `mongo_dict` and a schema whose root `required`
+    list is cleared. For dotted paths, traversed nested object schemas under
     `properties` also have `required` cleared.
+
+    Fast path: if `mongo_dict` has no dotted keys, returns the pre-computed
+    `schema_cleared_root` directly — no deep-copy. For dotted-keys, a fresh deep-copy
+    of `full_jsonschema` is made so nested mutations don't leak into the cache.
 
     NOTE: Does not support array/list dot-indexing
 
@@ -407,15 +392,16 @@ def _adapt_schema_for_partial_updating(
                 "required": []  # cleared for partial validation
             }
     """
-    adapted_schema = copy.deepcopy(full_jsonschema)
-    adapted_schema["required"] = []
-
-    # yes partial but no dots -> quick exit
+    # yes partial but no dots -> fast path; reuse the cached cleared-root schema
     if not _has_dotted_keys(mongo_dict):
-        return mongo_dict, adapted_schema
+        return mongo_dict, schema_cleared_root
+
+    # yes partial & yes dots -> fresh deep-copy (we will mutate nested `required` below)
+    adapted_schema = copy.deepcopy(full_jsonschema)
+    adapted_schema["required"] = []  # type: ignore[index]
 
     # https://stackoverflow.com/a/75734554/13156561 (looping logic)
-    out_dict = {}  # type: ignore
+    out_dict: MongoDoc = {}
     for og_key, value in mongo_dict.items():
         if "." not in og_key:
             out_dict[og_key] = value
@@ -423,11 +409,11 @@ def _adapt_schema_for_partial_updating(
         else:
             # (re)set cursors to root
             cursor = out_dict
-            schema_props_cursor = adapted_schema["properties"]
+            schema_props_cursor = adapted_schema["properties"]  # type: ignore[index]
             # iterate & attach keys
             *parent_keys, leaf_key = og_key.split(".")
             for k in parent_keys:
-                cursor = cursor.setdefault(k, {})
+                cursor = cursor.setdefault(k, {})  # type: ignore[assignment]
                 # mark nested object 'required' as none
                 if schema_props_cursor:
                     # ^^^ falsy when not "in" a properties obj, ex: parent only has 'additionalProperties'

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -4,7 +4,7 @@ import copy
 import functools
 import logging
 from collections.abc import AsyncIterator, Callable
-from typing import Any, TypeAlias
+from typing import Any, Final, TypeAlias
 
 # mongo imports
 try:
@@ -60,7 +60,9 @@ class MongoJSONSchemaValidatedCollection:
         validation_exception_callback: Callable[[Exception], Exception] | None = None,
     ) -> None:
         self._collection = collection
-        self._schema = collection_jsonschema_spec
+        self._jsonschema_transformer = _JSONSchemaTransformer(
+            collection_jsonschema_spec
+        )
 
         self.collection_name = collection.name
 
@@ -75,18 +77,6 @@ class MongoJSONSchemaValidatedCollection:
 
         self.validation_exception_callback = validation_exception_callback
 
-    @functools.cached_property
-    def _schema_cleared_root(self) -> JSON:
-        """Schema deep-copy with root `required` cleared; reused for the partial-update no-dots fast path.
-
-        Treat as immutable: callers must not mutate this value, or the cache will be
-        corrupted for the instance's lifetime. `jsonschema.validate` does not mutate
-        the schema it's given, so pass-through is safe.
-        """
-        cleared = copy.deepcopy(self._schema)
-        cleared["required"] = []  # type: ignore[index]
-        return cleared
-
     def _validate(
         self,
         obj: MongoDoc,
@@ -97,8 +87,7 @@ class MongoJSONSchemaValidatedCollection:
             jsonschema.validate(
                 *_convert_mongo_to_jsonschema(
                     obj,
-                    self._schema,
-                    self._schema_cleared_root,
+                    self._jsonschema_transformer,
                     allow_partial_update,
                 )
             )
@@ -303,8 +292,7 @@ def _has_dotted_keys(dicto: MongoDoc) -> bool:
 
 def _convert_mongo_to_jsonschema(
     mongo_dict: MongoDoc,
-    full_jsonschema: JSON,
-    schema_cleared_root: JSON,
+    jsonschema_transformer: "_JSONSchemaTransformer",
     allow_partial_update: bool,
 ) -> tuple[MongoDoc, JSON]:
     """Prepare a Mongo-style mapping and schema for JSON Schema validation.
@@ -313,113 +301,135 @@ def _convert_mongo_to_jsonschema(
     adapted so touched object levels no longer require unspecified sibling fields. For
     non-partial validation, dotted keys raise `IllegalDotsNotationActionException`.
 
-    `schema_cleared_root` is the cached deep-copy of `full_jsonschema` with the root
-    `required` cleared, used for the partial-update no-dots fast path.
-
     Returns a tuple of `(normalized_object, schema_for_validation)`.
 
     NOTE: Does not support array/list dot-indexing
     """
     if allow_partial_update:
-        return _adapt_schema_for_partial_updating(
-            mongo_dict, full_jsonschema, schema_cleared_root
+        return (
+            _mongo_expand_dotted_keys(mongo_dict),
+            jsonschema_transformer.unrequire_key_ancestors(mongo_dict),
         )
     else:
         # no partial & yes dots -> error
         if _has_dotted_keys(mongo_dict):
             raise IllegalDotsNotationActionException()
-        # no partial & no dots -> immediate exit
+        # no partial & no dots ->  no adaptations needed
         else:
-            return mongo_dict, full_jsonschema
+            return mongo_dict, jsonschema_transformer.full_schema
 
 
-def _adapt_schema_for_partial_updating(
-    mongo_dict: MongoDoc,
-    full_jsonschema: JSON,
-    schema_cleared_root: JSON,
-) -> tuple[MongoDoc, JSON]:
-    """Expand dotted update keys and relax `required` constraints for partial validation.
+class _JSONSchemaTransformer:
+    """Holds a jsonschema spec plus a cached builder for partial-update variants."""
 
-    Returns a nested object built from `mongo_dict` and a schema whose root `required`
-    list is cleared. For dotted paths, traversed nested object schemas under
-    `properties` also have `required` cleared.
+    def __init__(self, full_schema: JSON) -> None:
+        self.full_schema: Final[JSON] = full_schema
 
-    Fast path: if `mongo_dict` has no dotted keys, returns the pre-computed
-    `schema_cleared_root` directly — no deep-copy. For dotted-keys, a fresh deep-copy
-    of `full_jsonschema` is made so nested mutations don't leak into the cache.
+    def unrequire_key_ancestors(self, mongo_dict: MongoDoc) -> JSON:
+        """Return a deep-copy of `self.full_schema` with `required` cleared at the root
+        and along each dotted key's parent chain. Treat as immutable.
+
+        Example:
+            in:
+                {"book.title": "abc", "book.content": "def", "author": "ghi"}
+            self.full_schema:
+                {
+                    "type": "object",
+                    "properties": {
+                        "author": { "type": "string" },
+                        "book": {
+                            "type": "object",
+                            "properties": { "content": { "type": "string" } },
+                            "required": [<some>]
+                        },
+                        "copyright": {
+                            "type": "object",
+                            "properties": { ... },
+                            "required": [<some>]
+                        },
+                        ...
+                    },
+                    "required": [<some>]
+                }
+            out:
+                {
+                    "type": "object",
+                    "properties": {
+                        "author": { "type": "string" },
+                        "book": {
+                            "type": "object",
+                            "properties": { "content": { "type": "string" } },
+                            "required": []  # cleared for partial validation
+                        },
+                        "copyright": {
+                            "type": "object",
+                            "properties": { ... },
+                            "required": [<some>]  # unchanged because this branch was not traversed
+                        },
+                        ...
+                    },
+                    "required": []  # cleared for partial validation
+                }
+        """
+        return self._unrequire_key_ancestors(
+            frozenset(k for k in mongo_dict if "." in k)
+        )
+
+    @functools.lru_cache(maxsize=64)
+    def _unrequire_key_ancestors(self, dotted_keys: frozenset[str]) -> JSON:
+        """Cached builder for `unrequire_key_ancestors()`.
+
+        `frozenset` key makes cache hits order- and value-independent; `frozenset()`
+        is the no-dotted-keys case.
+        """
+        schema = copy.deepcopy(self.full_schema)  # expensive
+        schema["required"] = []  # type: ignore[index]
+        for dkey in dotted_keys:
+            # (re)set schema cursor to root for each key
+            schema_props_cursor = schema["properties"]  # type: ignore[index]
+            # leaf is the value slot, not a nested container to descend into
+            *parent_keys, _leaf_key = dkey.split(".")
+            for k in parent_keys:
+                # mark nested object 'required' as none
+                if schema_props_cursor:
+                    # ^^^ falsy when not "in" a properties obj, ex: parent only has 'additionalProperties'
+                    schema_props_cursor[k]["required"] = []
+                    schema_props_cursor = schema_props_cursor[k].get("properties")
+        return schema
+
+
+def _mongo_expand_dotted_keys(mongo_dict: MongoDoc) -> MongoDoc:
+    """Expand dotted update keys into a nested object for partial validation.
+
+    Non-dotted keys pass through unchanged.
 
     NOTE: Does not support array/list dot-indexing
 
     Example:
         in:
             {"book.title": "abc", "book.content": "def", "author": "ghi"}
-            {
-                "type": "object",
-                "properties": {
-                    "author": { "type": "string" },
-                    "book": {
-                        "type": "object",
-                        "properties": { "content": { "type": "string" } },
-                        "required": [<some>]
-                    },
-                    "copyright": {
-                        "type": "object",
-                        "properties": { ... },
-                        "required": [<some>]
-                    },
-                    ...
-                },
-                "required": [<some>]
-            }
         out:
             {"book": {"title": "abc", "content": "def"}, "author": "ghi"}
-            {
-                "type": "object",
-                "properties": {
-                    "author": { "type": "string" },
-                    "book": {
-                        "type": "object",
-                        "properties": { "content": { "type": "string" } },
-                        "required": []  # cleared for partial validation
-                    },
-                    "copyright": {
-                        "type": "object",
-                        "properties": { ... },
-                        "required": [<some>]  # unchanged because this branch was not traversed
-                    },
-                    ...
-                },
-                "required": []  # cleared for partial validation
-            }
     """
-    # yes partial but no dots -> fast path; reuse the cached cleared-root schema
-    if not _has_dotted_keys(mongo_dict):
-        return mongo_dict, schema_cleared_root
 
-    # yes partial & yes dots -> fresh deep-copy (we will mutate nested `required` below)
-    adapted_schema = copy.deepcopy(full_jsonschema)
-    adapted_schema["required"] = []  # type: ignore[index]
+    # yes partial but no dots -> quick exit
+    if not _has_dotted_keys(mongo_dict):
+        return mongo_dict
 
     # https://stackoverflow.com/a/75734554/13156561 (looping logic)
-    out_dict: MongoDoc = {}
+    out_dict = {}  # type: ignore
     for og_key, value in mongo_dict.items():
         if "." not in og_key:
             out_dict[og_key] = value
             continue
         else:
-            # (re)set cursors to root
+            # (re)set cursor to root
             cursor = out_dict
-            schema_props_cursor = adapted_schema["properties"]  # type: ignore[index]
             # iterate & attach keys
             *parent_keys, leaf_key = og_key.split(".")
             for k in parent_keys:
-                cursor = cursor.setdefault(k, {})  # type: ignore[assignment]
-                # mark nested object 'required' as none
-                if schema_props_cursor:
-                    # ^^^ falsy when not "in" a properties obj, ex: parent only has 'additionalProperties'
-                    schema_props_cursor[k]["required"] = []
-                    schema_props_cursor = schema_props_cursor[k].get("properties")
+                cursor = cursor.setdefault(k, {})
             # place value
             cursor[leaf_key] = value
 
-    return out_dict, adapted_schema
+    return out_dict

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -39,9 +39,9 @@ except (ImportError, ModuleNotFoundError) as _exc:
     ) from _exc
 
 if sys.version_info < (3, 12):
-    JSONType = dict[str, Any] | list | str | int | float | bool | None
+    JSON = dict[str, Any] | list | str | int | float | bool | None
 else:
-    type JSONType = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
+    type JSON = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
 
 
 class DocumentNotFoundException(Exception):


### PR DESCRIPTION
- Removes `motor` support in favor of `pymongo`'s async types
- Adds caching to schema transformations (like for partial updates)
- Adds typehints `JSON` AND `MongoDoc`


This is a **[minor]** bump because this removes `motor` functionality.