### PR TITLE
`mongo_jsonschema_tools`: Add `find_one_field()` [minor]

### DIFF
--- a/tests/mongo_jsonschema_tools_test.py
+++ b/tests/mongo_jsonschema_tools_test.py
@@ -538,6 +538,53 @@ async def test_1201__find_one_not_found_raises(
 
 
 ########################################################################################
+# find_one_field()
+
+
+@pytest.mark.asyncio
+async def test_1250__find_one_field_returns_value(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """Test find_one_field returns the value of the requested field."""
+    bio_coll.find_one = AsyncMock(  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
+        return_value={"name": "Alice", "age": 30}
+    )
+
+    result = await bio_coll.find_one_field({"name": "Alice"}, "age")
+
+    # check calls & result -- projection should be set to {field: 1}
+    bio_coll.find_one.assert_called_once_with(  # ty:ignore[unresolved-attribute]
+        {"name": "Alice"}, projection={"age": 1}
+    )
+    assert result == 30
+
+
+@pytest.mark.asyncio
+async def test_1251__find_one_field_dotted_key_raises(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """Test find_one_field raises ValueError for dotted (nested) field paths."""
+    bio_coll.find_one = AsyncMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
+
+    with pytest.raises(ValueError):
+        await bio_coll.find_one_field({"name": "Alice"}, "address.city")
+
+    # the wrapper should not be invoked at all when the input is malformed
+    bio_coll.find_one.assert_not_called()  # ty:ignore[unresolved-attribute]
+
+
+@pytest.mark.asyncio
+async def test_1252__find_one_field_not_found_raises(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """Test find_one_field propagates DocumentNotFoundException from find_one."""
+    bio_coll.find_one = AsyncMock(side_effect=DocumentNotFoundException)  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
+
+    with pytest.raises(DocumentNotFoundException):
+        await bio_coll.find_one_field({"name": "Missing"}, "age")
+
+
+########################################################################################
 # find_one_and_update()
 
 

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -40,6 +40,19 @@ class IllegalDotsNotationActionException(Exception):
         )
 
 
+def do_pop_id(no_id: bool, projection: dict[str, int] | list[str] | None) -> bool:
+    """Return whether to pop the `_id` field from the given doc.
+
+    If "_id" is included by the projection, it is not popped. Else, look at `no_id`.
+    """
+    if isinstance(projection, dict) and projection.get("_id"):  # {_id: 1} vs. {_id: 0}
+        return False
+    elif isinstance(projection, list) and "_id" in projection:  # ["_id"]
+        return False
+    else:
+        return no_id
+
+
 class MongoJSONSchemaValidatedCollection:
     """For interacting with a mongo collection using jsonschema validation for writes.
 
@@ -130,8 +143,8 @@ class MongoJSONSchemaValidatedCollection:
 
         self._validate(doc)
         await self._collection.insert_one(doc, **kwargs)
-        if no_id:
-            doc.pop("_id", None)  # mongo puts "_id"; could use projection instead
+        if do_pop_id(no_id, kwargs.get("projection")):
+            doc.pop("_id", None)
 
         self.logger.debug(f"inserted one: {doc}")
         return doc
@@ -158,8 +171,8 @@ class MongoJSONSchemaValidatedCollection:
         )
         if not doc:
             raise DocumentNotFoundException()
-        elif no_id:
-            doc.pop("_id", None)  # mongo puts "_id"; could use projection instead
+        elif do_pop_id(no_id, kwargs.get("projection")):
+            doc.pop("_id", None)
 
         self.logger.debug(f"updated one ({query}): {doc}")
         return doc  # type: ignore[no-any-return]
@@ -177,9 +190,9 @@ class MongoJSONSchemaValidatedCollection:
             self._validate(doc)
 
         await self._collection.insert_many(docs, **kwargs)
-        if no_id:
+        if do_pop_id(no_id, kwargs.get("projection")):
             for doc in docs:
-                doc.pop("_id", None)  # mongo puts "_id"; could use projection instead
+                doc.pop("_id", None)
 
         self.logger.debug(f"inserted many: {docs}")
         return docs
@@ -223,8 +236,8 @@ class MongoJSONSchemaValidatedCollection:
         doc = await self._collection.find_one(query, **kwargs)
         if not doc:
             raise DocumentNotFoundException()
-        if no_id:
-            doc.pop("_id", None)  # mongo puts "_id"; could use projection instead
+        if do_pop_id(no_id, kwargs.get("projection")):
+            doc.pop("_id", None)
 
         self.logger.debug(f"found one: {doc}")
         return doc  # type: ignore[no-any-return]
@@ -270,8 +283,8 @@ class MongoJSONSchemaValidatedCollection:
         i = 0
         async for doc in self._collection.find(query, projection, **kwargs):
             i += 1
-            if no_id:
-                doc.pop("_id", None)  # mongo puts "_id"; could use projection instead
+            if do_pop_id(no_id, kwargs.get("projection")):
+                doc.pop("_id", None)
             self.logger.debug(f"found {doc}")
             yield doc
 
@@ -296,8 +309,8 @@ class MongoJSONSchemaValidatedCollection:
         i = 0
         async for doc in cursor:
             i += 1
-            if no_id:
-                doc.pop("_id", None)  # mongo puts "_id"; could use projection instead
+            if do_pop_id(no_id, kwargs.get("projection")):
+                doc.pop("_id", None)
             self.logger.debug(f"found {doc}")
             yield doc
 

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -143,7 +143,10 @@ class MongoJSONSchemaValidatedCollection:
         no_id: bool = True,
         **kwargs: Any,
     ) -> MongoDoc:
-        """Update the doc and return updated doc."""
+        """Update the doc and return updated doc.
+
+        Raises `DocumentNotFoundException` if no doc is found.
+        """
         self.logger.debug(f"update one with query: {query}")
 
         self._validate_mongo_update(update)
@@ -187,7 +190,10 @@ class MongoJSONSchemaValidatedCollection:
         update: MongoDoc,
         **kwargs: Any,
     ) -> int:
-        """Update all matching docs."""
+        """Update all matching docs.
+
+        Raises `DocumentNotFoundException` if no doc is found.
+        """
         self.logger.debug(f"update many with query: {query}")
 
         self._validate_mongo_update(update)
@@ -208,7 +214,10 @@ class MongoJSONSchemaValidatedCollection:
         no_id: bool = True,
         **kwargs: Any,
     ) -> MongoDoc:
-        """Find one matching the query."""
+        """Find one matching the query.
+
+        Raises `DocumentNotFoundException` if no doc is found.
+        """
         self.logger.debug(f"finding one with query: {query}")
 
         doc = await self._collection.find_one(query, **kwargs)
@@ -246,6 +255,8 @@ class MongoJSONSchemaValidatedCollection:
         """Find all matching the query.
 
         Argument `projection` is required to emphasize this could return A LOT of data.
+
+        Yields nothing if no docs are found.
         """
         self.logger.debug(f"finding with query: {query}")
 
@@ -265,7 +276,10 @@ class MongoJSONSchemaValidatedCollection:
         no_id: bool = True,
         **kwargs: Any,
     ) -> AsyncIterator[MongoDoc]:
-        """Find all matching the aggregate pipeline."""
+        """Find all matching the aggregate pipeline.
+
+        Yields nothing if no docs are found.
+        """
         self.logger.debug(f"finding with aggregate pipeline: {pipeline}")
 
         # PyMongo async's AsyncCollection.aggregate() returns a coroutine
@@ -290,6 +304,8 @@ class MongoJSONSchemaValidatedCollection:
         """Find one matching the aggregate pipeline.
 
         Appends `{"$limit": 1}` to pipeline.
+
+        Raises `DocumentNotFoundException` if no doc is found.
         """
         self.logger.debug(f"finding one with aggregate pipeline: {pipeline}")
 

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -220,6 +220,22 @@ class MongoJSONSchemaValidatedCollection:
         self.logger.debug(f"found one: {doc}")
         return doc  # type: ignore[no-any-return]
 
+    async def find_one_field(
+        self,
+        query: MongoDoc,
+        field: str,
+        **kwargs: Any,
+    ) -> Any:
+        """Find one doc matching the query, then return the *value* of `field`.
+
+        Do not provide `projection` -- this method will override it with `{field: 1}`.
+
+        Raises `DocumentNotFoundException` if no doc is found.
+        """
+        kwargs["projection"] = {field: 1}
+        doc = await self.find_one(query, **kwargs)  # ~> DocumentNotFoundException
+        return doc[field]
+
     async def find_all(
         self,
         query: MongoDoc,

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -237,10 +237,17 @@ class MongoJSONSchemaValidatedCollection:
     ) -> Any:
         """Find one doc matching the query, then return the *value* of `field`.
 
+        **WARNING**: Do not pass in dotted keys, this will raise a `ValueError`.
+        The logic to support this is very complex and would need to account for various
+        shapes of nested objects, including arrays and mixed types.
+
         Do not provide `projection` -- this method will override it with `{field: 1}`.
 
         Raises `DocumentNotFoundException` if no doc is found.
         """
+        if "." in field:
+            raise ValueError("Dotted keys are not supported for this method.")
+
         kwargs["projection"] = {field: 1}
         doc = await self.find_one(query, **kwargs)  # ~> DocumentNotFoundException
         return doc[field]


### PR DESCRIPTION
New method, `MongoJSONSchemaValidatedCollection.find_one_field()`, finds a doc, then returns the value of that field. 

This shortens the pattern from:
```
doc = await coll.find_one({"bar": bar}, projection=["foo"])
foo = doc["foo"]
del doc  # optional
```
to:
```
foo = await coll.find_one_field({"bar": bar}, "foo")
```

Plus, this saves more IDE space for queries with longer field names.