### PR TITLE
`mongo_jsonschema_tools`: support more update operators [minor]

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -179,7 +179,6 @@ jobs:
     needs: [
       mongo-versions,
       py-versions,
-      lint,
     ]
     strategy:
       fail-fast: true

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -8,6 +8,23 @@ on:
 
 jobs:
 
+  #############################################################################
+  # TOOLS FOR SETTING UP MATRIX-BASED JOBS
+  #############################################################################
+
+  mongo-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}  # lock to triggered commit (github.ref is dynamic)
+      - id: versions
+        uses: WIPACrepo/wipac-dev-mongo-versions-action@v2
+        with:
+          mongo_min: "5.0"
+
   py-versions:
     runs-on: ubuntu-latest
     outputs:
@@ -157,6 +174,45 @@ jobs:
             pytest -vvvv "tests/${{ steps.parse.outputs.file }}"
           fi
 
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: [
+      mongo-versions,
+      py-versions,
+      lint,
+    ]
+    strategy:
+      fail-fast: true
+      matrix:
+        py3: ${{ fromJSON(needs.py-versions.outputs.matrix) }}
+        mongo: ${{ fromJSON(needs.mongo-versions.outputs.matrix) }}
+    services:
+      mongo:
+        image: mongo:${{ matrix.mongo }}
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ ping: 1 }).ok'"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}  # lock to triggered commit (github.ref is dynamic)
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py3 }}
+      - name: Install
+        run: |
+          set -euo pipefail
+          pip install --upgrade pip
+          pip install -e .[jsonschema,mongo,test]
+      - name: Run integration tests
+        env:
+          MONGO_URL: mongodb://localhost:27017
+        run: pytest -vvv tests/integration
+
 
   ############################################################################
   # TAG + RELEASE
@@ -166,11 +222,13 @@ jobs:
     # only run on main/default
     if: format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
     needs: [
+      mongo-versions,
       py-versions,
       lint,
       py-setup,
       py-dependencies,
       tests,
+      integration-tests
     ]
     uses: WIPACrepo/wipac-dev-workflows/.github/workflows/tag-and-release.yml@v1.26
     permissions: # for GITHUB_TOKEN

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           set -euo pipefail
           pip install --upgrade pip
-          pip install -e .[jsonschema,mongo,test]
+          pip install -e .[jsonschema,mongo,tests]
       - name: Run integration tests
         env:
           MONGO_URL: mongodb://localhost:27017

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -174,7 +174,7 @@ jobs:
             pytest -vvvv "tests/${{ steps.parse.outputs.file }}"
           fi
 
-  integration-tests:
+  integration-tests-mongo-jsonschema:
     runs-on: ubuntu-latest
     needs: [
       mongo-versions,
@@ -213,7 +213,7 @@ jobs:
           MONGO_URL: mongodb://localhost:27017
         run: |
           set -euo pipefail
-          pytest -vvvv tests/integration
+          pytest -vvvv tests/integration/mongo_jsonschema_tools_integrate.py
 
 
   ############################################################################
@@ -230,7 +230,7 @@ jobs:
       py-setup,
       py-dependencies,
       tests,
-      integration-tests
+      integration-tests-mongo-jsonschema,
     ]
     uses: WIPACrepo/wipac-dev-workflows/.github/workflows/tag-and-release.yml@v1.26
     permissions: # for GITHUB_TOKEN

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -211,7 +211,9 @@ jobs:
       - name: Run integration tests
         env:
           MONGO_URL: mongodb://localhost:27017
-        run: pytest -vvv tests/integration
+        run: |
+          set -euo pipefail
+          pytest -vvvv tests/integration
 
 
   ############################################################################

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -196,10 +196,11 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
+          fetch-depth: 0  # setuptools-scm needs to access git tags
           ref: ${{ github.sha }}  # lock to triggered commit (github.ref is dynamic)
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.py3 }}
       - name: Install

--- a/tests/integration/mongo_jsonschema_tools_integrate.py
+++ b/tests/integration/mongo_jsonschema_tools_integrate.py
@@ -1,0 +1,444 @@
+"""Integration tests for mongo_jsonschema_tools.py.
+
+Runs against a real MongoDB instance. Connection URL is taken from the
+MONGO_URL env var (default: mongodb://localhost:27017).
+
+Skipped by default unless `-m integration` is passed (or unmarked default
+config picks them up). Run locally with:
+    docker run --rm -p 27017:27017 mongo:7
+    pytest -m integration tests/mongo_jsonschema_tools_integration_test.py
+
+Focus areas:
+    - Wiring: kwargs/return shapes between wrapper and pymongo (mocks miss this).
+    - Each supported $-operator end-to-end against real mongo.
+    - DocumentNotFoundException semantics on real misses.
+"""
+
+import logging
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+from pymongo import AsyncMongoClient
+from wipac_dev_tools.mongo_jsonschema_tools import (
+    DocumentNotFoundException,
+    MongoJSONSchemaValidatedCollection,
+)
+
+MONGO_URL = os.environ.get("MONGO_URL", "mongodb://localhost:27017")
+
+# all tests in this file are integration tests
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+########################################################################################
+# fixtures
+
+
+@pytest_asyncio.fixture
+async def mongo_client():
+    """Yield a fresh AsyncMongoClient for the test."""
+    client = AsyncMongoClient(MONGO_URL)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest_asyncio.fixture
+async def raw_collection(mongo_client):
+    """Yield an isolated AsyncCollection per test, then drop it."""
+    db = mongo_client["wdt_integration_test"]
+    # unique name per test -> no cross-test contamination if drop fails
+    coll = db[f"coll_{uuid.uuid4().hex}"]
+    yield coll
+    await coll.drop()
+
+
+@pytest.fixture
+def stadium_schema():
+    """Schema for baseball stadium docs used across most integration tests."""
+    return {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "capacity": {"type": "integer"},
+            "attendance_avg": {"type": "number"},
+            "concessions": {"type": "array", "items": {"type": "string"}},
+            "location": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "state": {"type": "string"},
+                },
+                "required": ["city", "state"],
+            },
+        },
+        "required": ["name", "capacity"],
+    }
+
+
+@pytest_asyncio.fixture
+async def stadium_coll(raw_collection, stadium_schema):
+    """Yield a MongoJSONSchemaValidatedCollection over a fresh raw collection."""
+    return MongoJSONSchemaValidatedCollection(
+        collection=raw_collection,
+        collection_jsonschema_spec=stadium_schema,
+        parent_logger=logging.getLogger("integration_test"),
+    )
+
+
+########################################################################################
+# insert_one() / find_one() -- round trip
+
+
+async def test_2000__insert_then_find(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """Round-trip a doc through insert_one + find_one."""
+    await stadium_coll.insert_one({"name": "Miller Park", "capacity": 41000})
+
+    found = await stadium_coll.find_one({"name": "Miller Park"})
+    assert found == {"name": "Miller Park", "capacity": 41000}
+
+
+async def test_2001__find_one_missing_raises(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """find_one raises DocumentNotFoundException when no doc matches."""
+    with pytest.raises(DocumentNotFoundException):
+        await stadium_coll.find_one({"name": "Nonexistent Park"})
+
+
+async def test_2002__insert_many_round_trip(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """insert_many then find_all yields all docs."""
+    docs = [
+        {"name": "Miller Park", "capacity": 41000},
+        {"name": "Wrigley Field", "capacity": 37000},
+        {"name": "Chase Field", "capacity": 47000},
+    ]
+    await stadium_coll.insert_many([d.copy() for d in docs])
+
+    out = sorted(
+        [doc async for doc in stadium_coll.find_all({}, ["name", "capacity"])],
+        key=lambda d: d["name"],
+    )
+    assert out == sorted(docs, key=lambda d: d["name"])
+
+
+########################################################################################
+# find_one_and_update() -- one test per supported $-operator
+
+
+async def test_2100__set(stadium_coll: MongoJSONSchemaValidatedCollection):
+    """$set updates the field and returns the AFTER doc."""
+    await stadium_coll.insert_one({"name": "Miller Park", "capacity": 41000})
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$set": {"capacity": 41649}}
+    )
+    assert out["capacity"] == 41649
+
+
+async def test_2101__set_on_insert_with_upsert(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$setOnInsert applies only when upsert creates a new doc."""
+    # upsert creates new -> setOnInsert applies
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Brand New Park"},
+        {"$setOnInsert": {"name": "Brand New Park", "capacity": 1}},
+        upsert=True,
+    )
+    assert out["capacity"] == 1
+
+    # second call against existing doc -> setOnInsert is a no-op
+    out2 = await stadium_coll.find_one_and_update(
+        {"name": "Brand New Park"},
+        {"$setOnInsert": {"capacity": 99999}},
+        upsert=True,
+    )
+    assert out2["capacity"] == 1  # unchanged
+
+
+async def test_2102__inc(stadium_coll: MongoJSONSchemaValidatedCollection):
+    """$inc increments the field by the given delta."""
+    await stadium_coll.insert_one({"name": "Miller Park", "capacity": 10000})
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$inc": {"capacity": 5}}
+    )
+    assert out["capacity"] == 10005
+
+
+async def test_2103__min_lowers_value(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$min keeps the smaller of {existing, supplied}."""
+    await stadium_coll.insert_one({"name": "Miller Park", "capacity": 10000})
+
+    # 5000 < 10000 -> updates to 5000
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$min": {"capacity": 5000}}
+    )
+    assert out["capacity"] == 5000
+
+    # 7000 > 5000 -> stays at 5000
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$min": {"capacity": 7000}}
+    )
+    assert out["capacity"] == 5000
+
+
+async def test_2104__max_raises_value(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$max keeps the larger of {existing, supplied}."""
+    await stadium_coll.insert_one({"name": "Miller Park", "capacity": 10000})
+
+    # 50000 > 10000 -> updates to 50000
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$max": {"capacity": 50000}}
+    )
+    assert out["capacity"] == 50000
+
+    # 5000 < 50000 -> stays at 50000
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$max": {"capacity": 5000}}
+    )
+    assert out["capacity"] == 50000
+
+
+async def test_2105__mul(stadium_coll: MongoJSONSchemaValidatedCollection):
+    """$mul multiplies the field by the given factor."""
+    await stadium_coll.insert_one(
+        {"name": "Miller Park", "capacity": 10000, "attendance_avg": 25000.0}
+    )
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$mul": {"attendance_avg": 2}}
+    )
+    assert out["attendance_avg"] == 50000.0  # 25000 * 2
+
+
+async def test_2106__push(stadium_coll: MongoJSONSchemaValidatedCollection):
+    """$push appends to the array."""
+    await stadium_coll.insert_one(
+        {"name": "Miller Park", "capacity": 10000, "concessions": ["hot_dog"]}
+    )
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$push": {"concessions": "peanuts"}}
+    )
+    assert out["concessions"] == ["hot_dog", "peanuts"]
+
+
+async def test_2107__add_to_set_dedups(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$addToSet appends only if the value isn't already present."""
+    await stadium_coll.insert_one(
+        {"name": "Miller Park", "capacity": 10000, "concessions": ["hot_dog"]}
+    )
+
+    # new value -> appended
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$addToSet": {"concessions": "peanuts"}}
+    )
+    assert out["concessions"] == ["hot_dog", "peanuts"]
+
+    # duplicate -> ignored
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$addToSet": {"concessions": "peanuts"}}
+    )
+    assert out["concessions"] == ["hot_dog", "peanuts"]
+
+
+async def test_2108__pop_last(stadium_coll: MongoJSONSchemaValidatedCollection):
+    """$pop with 1 removes the last element."""
+    await stadium_coll.insert_one(
+        {
+            "name": "Miller Park",
+            "capacity": 10000,
+            "concessions": ["hot_dog", "peanuts", "beer"],
+        }
+    )
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$pop": {"concessions": 1}}
+    )
+    assert out["concessions"] == ["hot_dog", "peanuts"]
+
+
+async def test_2109__pop_first(stadium_coll: MongoJSONSchemaValidatedCollection):
+    """$pop with -1 removes the first element."""
+    await stadium_coll.insert_one(
+        {
+            "name": "Miller Park",
+            "capacity": 10000,
+            "concessions": ["hot_dog", "peanuts", "beer"],
+        }
+    )
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$pop": {"concessions": -1}}
+    )
+    assert out["concessions"] == ["peanuts", "beer"]
+
+
+async def test_2110__pull(stadium_coll: MongoJSONSchemaValidatedCollection):
+    """$pull removes ALL elements matching the value."""
+    await stadium_coll.insert_one(
+        {
+            "name": "Miller Park",
+            "capacity": 10000,
+            # duplicate hot_dog entries to verify $pull removes every match
+            "concessions": ["hot_dog", "peanuts", "hot_dog", "beer"],
+        }
+    )
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$pull": {"concessions": "hot_dog"}}
+    )
+    assert out["concessions"] == ["peanuts", "beer"]
+
+
+async def test_2111__pull_all(stadium_coll: MongoJSONSchemaValidatedCollection):
+    """$pullAll removes any element matching any in the supplied list."""
+    await stadium_coll.insert_one(
+        {
+            "name": "Miller Park",
+            "capacity": 10000,
+            "concessions": ["hot_dog", "peanuts", "beer", "popcorn"],
+        }
+    )
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"},
+        {"$pullAll": {"concessions": ["hot_dog", "popcorn"]}},
+    )
+    assert out["concessions"] == ["peanuts", "beer"]
+
+
+async def test_2120__find_one_and_update_missing_raises(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """find_one_and_update raises when no match (and upsert is off)."""
+    with pytest.raises(DocumentNotFoundException):
+        await stadium_coll.find_one_and_update(
+            {"name": "Ghost Park"}, {"$set": {"capacity": 99}}
+        )
+
+
+async def test_2121__set_with_dotted_partial_preserves_siblings(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$set with dotted keys updates nested fields without overwriting siblings."""
+    await stadium_coll.insert_one(
+        {
+            "name": "Miller Park",
+            "capacity": 41000,
+            "location": {"city": "Milwaukee", "state": "WI"},
+        }
+    )
+    # update only the city; state should be preserved
+    out = await stadium_coll.find_one_and_update(
+        {"name": "Miller Park"}, {"$set": {"location.city": "Madison"}}
+    )
+    assert out["location"] == {"city": "Madison", "state": "WI"}
+
+
+########################################################################################
+# update_many()
+
+
+async def test_2200__update_many_inc(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """update_many applies $inc to every matching doc."""
+    await stadium_coll.insert_many(
+        [
+            {"name": "Miller Park", "capacity": 10000},
+            {"name": "Wrigley Field", "capacity": 20000},
+            {"name": "Chase Field", "capacity": 30000},
+        ]
+    )
+
+    n = await stadium_coll.update_many({}, {"$inc": {"capacity": 1}})
+    assert n == 3
+
+    out = sorted(
+        [doc async for doc in stadium_coll.find_all({}, ["capacity"])],
+        key=lambda d: d["capacity"],
+    )
+    assert [d["capacity"] for d in out] == [10001, 20001, 30001]
+
+
+async def test_2201__update_many_no_match_raises(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """update_many raises when no doc matches."""
+    with pytest.raises(DocumentNotFoundException):
+        await stadium_coll.update_many({"name": "ghost"}, {"$set": {"capacity": 1}})
+
+
+########################################################################################
+# find_all() / aggregate() / aggregate_one()
+
+
+async def test_2300__find_all_with_projection(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """find_all yields docs with the projection applied (and _id stripped)."""
+    await stadium_coll.insert_many(
+        [
+            {"name": "Miller Park", "capacity": 10000},
+            {"name": "Wrigley Field", "capacity": 20000},
+        ]
+    )
+    out = sorted(
+        [doc async for doc in stadium_coll.find_all({}, {"name": 1, "_id": 0})],
+        key=lambda d: d["name"],
+    )
+    # _id stripped, capacity not projected
+    assert out == [{"name": "Wrigley Field"}, {"name": "Miller Park"}]
+
+
+async def test_2301__aggregate_match_and_project(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """aggregate runs through the wrapper and yields filtered/projected docs."""
+    await stadium_coll.insert_many(
+        [
+            {"name": "Miller Park", "capacity": 10000},
+            {"name": "Wrigley Field", "capacity": 20000},
+        ]
+    )
+    out = [
+        doc
+        async for doc in stadium_coll.aggregate(
+            [
+                {"$match": {"capacity": {"$gte": 15000}}},
+                {"$project": {"_id": 0, "name": 1}},
+            ]
+        )
+    ]
+    assert out == [{"name": "Wrigley Field"}]
+
+
+async def test_2302__aggregate_one_returns_first(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """aggregate_one returns the first matching doc and appends $limit:1."""
+    await stadium_coll.insert_many(
+        [
+            {"name": "Miller Park", "capacity": 10000},
+            {"name": "Wrigley Field", "capacity": 20000},
+        ]
+    )
+    out = await stadium_coll.aggregate_one([{"$match": {}}, {"$sort": {"capacity": 1}}])
+    # smallest-capacity-first sort -> Wrigley
+    assert out["name"] == "Miller Park"
+
+
+async def test_2303__aggregate_one_missing_raises(
+    stadium_coll: MongoJSONSchemaValidatedCollection,
+):
+    """aggregate_one raises DocumentNotFoundException on no match."""
+    with pytest.raises(DocumentNotFoundException):
+        await stadium_coll.aggregate_one([{"$match": {"name": "ghost"}}])

--- a/tests/integration/mongo_jsonschema_tools_integrate.py
+++ b/tests/integration/mongo_jsonschema_tools_integrate.py
@@ -28,10 +28,6 @@ from wipac_dev_tools.mongo_jsonschema_tools import (
 
 MONGO_URL = os.environ.get("MONGO_URL", "mongodb://localhost:27017")
 
-# all tests in this file are integration tests
-pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
-
-
 ########################################################################################
 # fixtures
 

--- a/tests/integration/mongo_jsonschema_tools_integrate.py
+++ b/tests/integration/mongo_jsonschema_tools_integrate.py
@@ -21,7 +21,6 @@ import uuid
 import pytest
 import pytest_asyncio
 from pymongo import AsyncMongoClient
-
 from wipac_dev_tools.mongo_jsonschema_tools import (
     DocumentNotFoundException,
     MongoJSONSchemaValidatedCollection,
@@ -122,7 +121,7 @@ async def test_2002__insert_many_round_trip(
     out = sorted(
         [doc async for doc in stadium_coll.find_all({}, ["name", "capacity"])],
         key=lambda d: d["name"],
-    )
+    )  # type: ignore[arg-type,return-value]
     assert out == sorted(docs, key=lambda d: d["name"])
 
 

--- a/tests/integration/mongo_jsonschema_tools_integrate.py
+++ b/tests/integration/mongo_jsonschema_tools_integrate.py
@@ -21,6 +21,7 @@ import uuid
 import pytest
 import pytest_asyncio
 from pymongo import AsyncMongoClient
+
 from wipac_dev_tools.mongo_jsonschema_tools import (
     DocumentNotFoundException,
     MongoJSONSchemaValidatedCollection,

--- a/tests/integration/mongo_jsonschema_tools_integrate.py
+++ b/tests/integration/mongo_jsonschema_tools_integrate.py
@@ -123,7 +123,7 @@ async def test_2002__insert_many_round_trip(
         [doc async for doc in stadium_coll.find_all({}, ["name", "capacity"])],
         key=lambda d: d["name"],
     )  # type: ignore[arg-type,return-value]
-    assert out == sorted(docs, key=lambda d: d["name"])
+    assert out == sorted(docs, key=lambda d: d["name"])  # type: ignore[arg-type,return-value]
 
 
 ########################################################################################

--- a/tests/integration/mongo_jsonschema_tools_integrate.py
+++ b/tests/integration/mongo_jsonschema_tools_integrate.py
@@ -224,12 +224,12 @@ async def test_2105__mul(stadium_coll: MongoJSONSchemaValidatedCollection):
 async def test_2106__push(stadium_coll: MongoJSONSchemaValidatedCollection):
     """$push appends to the array."""
     await stadium_coll.insert_one(
-        {"name": "Miller Park", "capacity": 10000, "concessions": ["hot_dog"]}
+        {"name": "Miller Park", "capacity": 10000, "concessions": ["brat"]}
     )
     out = await stadium_coll.find_one_and_update(
-        {"name": "Miller Park"}, {"$push": {"concessions": "peanuts"}}
+        {"name": "Miller Park"}, {"$push": {"concessions": "pretzels"}}
     )
-    assert out["concessions"] == ["hot_dog", "peanuts"]
+    assert out["concessions"] == ["brat", "pretzels"]
 
 
 async def test_2107__add_to_set_dedups(
@@ -237,20 +237,20 @@ async def test_2107__add_to_set_dedups(
 ):
     """$addToSet appends only if the value isn't already present."""
     await stadium_coll.insert_one(
-        {"name": "Miller Park", "capacity": 10000, "concessions": ["hot_dog"]}
+        {"name": "Miller Park", "capacity": 10000, "concessions": ["brat"]}
     )
 
     # new value -> appended
     out = await stadium_coll.find_one_and_update(
-        {"name": "Miller Park"}, {"$addToSet": {"concessions": "peanuts"}}
+        {"name": "Miller Park"}, {"$addToSet": {"concessions": "pretzels"}}
     )
-    assert out["concessions"] == ["hot_dog", "peanuts"]
+    assert out["concessions"] == ["brat", "pretzels"]
 
     # duplicate -> ignored
     out = await stadium_coll.find_one_and_update(
-        {"name": "Miller Park"}, {"$addToSet": {"concessions": "peanuts"}}
+        {"name": "Miller Park"}, {"$addToSet": {"concessions": "pretzels"}}
     )
-    assert out["concessions"] == ["hot_dog", "peanuts"]
+    assert out["concessions"] == ["brat", "pretzels"]
 
 
 async def test_2108__pop_last(stadium_coll: MongoJSONSchemaValidatedCollection):
@@ -259,13 +259,13 @@ async def test_2108__pop_last(stadium_coll: MongoJSONSchemaValidatedCollection):
         {
             "name": "Miller Park",
             "capacity": 10000,
-            "concessions": ["hot_dog", "peanuts", "beer"],
+            "concessions": ["brat", "pretzels", "beer"],
         }
     )
     out = await stadium_coll.find_one_and_update(
         {"name": "Miller Park"}, {"$pop": {"concessions": 1}}
     )
-    assert out["concessions"] == ["hot_dog", "peanuts"]
+    assert out["concessions"] == ["brat", "pretzels"]
 
 
 async def test_2109__pop_first(stadium_coll: MongoJSONSchemaValidatedCollection):
@@ -274,13 +274,13 @@ async def test_2109__pop_first(stadium_coll: MongoJSONSchemaValidatedCollection)
         {
             "name": "Miller Park",
             "capacity": 10000,
-            "concessions": ["hot_dog", "peanuts", "beer"],
+            "concessions": ["brat", "pretzels", "beer"],
         }
     )
     out = await stadium_coll.find_one_and_update(
         {"name": "Miller Park"}, {"$pop": {"concessions": -1}}
     )
-    assert out["concessions"] == ["peanuts", "beer"]
+    assert out["concessions"] == ["pretzels", "beer"]
 
 
 async def test_2110__pull(stadium_coll: MongoJSONSchemaValidatedCollection):
@@ -289,14 +289,14 @@ async def test_2110__pull(stadium_coll: MongoJSONSchemaValidatedCollection):
         {
             "name": "Miller Park",
             "capacity": 10000,
-            # duplicate hot_dog entries to verify $pull removes every match
-            "concessions": ["hot_dog", "peanuts", "hot_dog", "beer"],
+            # duplicate brat entries to verify $pull removes every match
+            "concessions": ["brat", "pretzels", "brat", "beer"],
         }
     )
     out = await stadium_coll.find_one_and_update(
-        {"name": "Miller Park"}, {"$pull": {"concessions": "hot_dog"}}
+        {"name": "Miller Park"}, {"$pull": {"concessions": "brat"}}
     )
-    assert out["concessions"] == ["peanuts", "beer"]
+    assert out["concessions"] == ["pretzels", "beer"]
 
 
 async def test_2111__pull_all(stadium_coll: MongoJSONSchemaValidatedCollection):
@@ -305,14 +305,14 @@ async def test_2111__pull_all(stadium_coll: MongoJSONSchemaValidatedCollection):
         {
             "name": "Miller Park",
             "capacity": 10000,
-            "concessions": ["hot_dog", "peanuts", "beer", "popcorn"],
+            "concessions": ["brat", "pretzels", "beer", "popcorn"],
         }
     )
     out = await stadium_coll.find_one_and_update(
         {"name": "Miller Park"},
-        {"$pullAll": {"concessions": ["hot_dog", "popcorn"]}},
+        {"$pullAll": {"concessions": ["brat", "popcorn"]}},
     )
-    assert out["concessions"] == ["peanuts", "beer"]
+    assert out["concessions"] == ["pretzels", "beer"]
 
 
 async def test_2120__find_one_and_update_missing_raises(
@@ -396,7 +396,7 @@ async def test_2300__find_all_with_projection(
         key=lambda d: d["name"],
     )
     # _id stripped, capacity not projected
-    assert out == [{"name": "Wrigley Field"}, {"name": "Miller Park"}]
+    assert out == [{"name": "Miller Park"}, {"name": "Wrigley Field"}]
 
 
 async def test_2301__aggregate_match_and_project(
@@ -432,7 +432,7 @@ async def test_2302__aggregate_one_returns_first(
         ]
     )
     out = await stadium_coll.aggregate_one([{"$match": {}}, {"$sort": {"capacity": 1}}])
-    # smallest-capacity-first sort -> Wrigley
+    # smallest-capacity-first sort -> Miller (10000 < 20000)
     assert out["name"] == "Miller Park"
 
 

--- a/tests/mongo_jsonschema_tools_test.py
+++ b/tests/mongo_jsonschema_tools_test.py
@@ -455,6 +455,146 @@ def test_0204__validate_mongo_update__push_baseball_invalid(team_schema):
         coll._validate_mongo_update(update)
 
 
+def test_0205__validate_mongo_update__set_on_insert(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$setOnInsert validates like $set (partial allowed)."""
+    bio_coll._validate_mongo_update({"$setOnInsert": {"name": "Alice"}})
+
+
+def test_0206__validate_mongo_update__set_on_insert_invalid(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$setOnInsert with wrong type raises ValidationError."""
+    with pytest.raises(ValidationError):
+        bio_coll._validate_mongo_update({"$setOnInsert": {"age": "not-int"}})
+
+
+def test_0210__validate_mongo_update__min(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$min validates value type per schema."""
+    bio_coll._validate_mongo_update({"$min": {"age": 10}})
+
+
+def test_0211__validate_mongo_update__min_invalid(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$min with wrong type fails validation."""
+    with pytest.raises(ValidationError):
+        bio_coll._validate_mongo_update({"$min": {"age": "ten"}})
+
+
+def test_0212__validate_mongo_update__max(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$max validates value type per schema."""
+    bio_coll._validate_mongo_update({"$max": {"age": 99}})
+
+
+def test_0213__validate_mongo_update__max_invalid(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$max with wrong type fails validation."""
+    with pytest.raises(ValidationError):
+        bio_coll._validate_mongo_update({"$max": {"age": "ninety"}})
+
+
+def test_0214__validate_mongo_update__inc(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$inc validates value type per schema."""
+    bio_coll._validate_mongo_update({"$inc": {"age": 1}})
+
+
+def test_0215__validate_mongo_update__inc_invalid(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$inc with wrong type fails validation."""
+    with pytest.raises(ValidationError):
+        bio_coll._validate_mongo_update({"$inc": {"age": "1"}})
+
+
+def test_0216__validate_mongo_update__mul(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$mul validates value type per schema."""
+    bio_coll._validate_mongo_update({"$mul": {"age": 2}})
+
+
+def test_0217__validate_mongo_update__mul_invalid(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$mul with wrong type fails validation."""
+    with pytest.raises(ValidationError):
+        bio_coll._validate_mongo_update({"$mul": {"age": "x2"}})
+
+
+def test_0220__validate_mongo_update__add_to_set(team_schema):
+    """$addToSet validates as a one-item array push."""
+    coll = make_coll(team_schema)
+    coll._validate_mongo_update(
+        {"$addToSet": {"team": {"name": "Mia", "position": "P", "number": 7}}}
+    )
+
+
+def test_0221__validate_mongo_update__add_to_set_invalid(team_schema):
+    """$addToSet with bad item shape fails validation."""
+    coll = make_coll(team_schema)
+    update = {"$addToSet": {"team": {"name": "Mia"}}}  # missing position+number
+    with pytest.raises(ValidationError):
+        coll._validate_mongo_update(update)
+
+
+def test_0230__validate_mongo_update__pop_skipped(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$pop is intentionally not locally validated -- mongo handles shape."""
+    # 1 = pop last, -1 = pop first; we deliberately pass through to mongo
+    bio_coll._validate_mongo_update({"$pop": {"tags": 1}})
+    bio_coll._validate_mongo_update({"$pop": {"tags": -1}})
+    # even garbage passes our wrapper; mongo would reject at write time
+    bio_coll._validate_mongo_update({"$pop": {"tags": "garbage"}})
+
+
+def test_0231__validate_mongo_update__pull_skipped(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$pull is not locally validated -- mongo handles it."""
+    bio_coll._validate_mongo_update({"$pull": {"tags": "red"}})
+
+
+def test_0232__validate_mongo_update__pull_all_skipped(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$pullAll is not locally validated -- mongo handles it."""
+    bio_coll._validate_mongo_update({"$pullAll": {"tags": ["red", "blue"]}})
+
+
+def test_0240__validate_mongo_update__unset_unsupported(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$unset is unsupported by design."""
+    with pytest.raises(UnsupportedMongoActionError):
+        bio_coll._validate_mongo_update({"$unset": {"age": ""}})
+
+
+def test_0241__validate_mongo_update__current_date_unsupported(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """$currentDate is unsupported by design."""
+    with pytest.raises(UnsupportedMongoActionError):
+        bio_coll._validate_mongo_update({"$currentDate": {"updated": True}})
+
+
+def test_0242__validate_mongo_update__unknown_operator_unsupported(
+    bio_coll: MongoJSONSchemaValidatedCollection,
+):
+    """Unknown operators (e.g. $bit) raise UnsupportedMongoActionError."""
+    with pytest.raises(UnsupportedMongoActionError):
+        bio_coll._validate_mongo_update({"$bit": {"flags": {"and": 5}}})
+
+
 ########################################################################################
 # insert_one()
 

--- a/tests/mongo_jsonschema_tools_test.py
+++ b/tests/mongo_jsonschema_tools_test.py
@@ -5,13 +5,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import jsonschema
 import pytest
-
 from wipac_dev_tools.mongo_jsonschema_tools import (
     DocumentNotFoundException,
     IllegalDotsNotationActionException,
     MongoJSONSchemaValidatedCollection,
-    _JSONSchemaTransformer,
+    UnsupportedMongoActionError,
     _convert_mongo_to_jsonschema,
+    _JSONSchemaTransformer,
 )
 
 ValidationError = jsonschema.exceptions.ValidationError
@@ -419,7 +419,7 @@ def test_0200__validate_mongo_update__unsupported_operator(
 ):
     """Test _validate_mongo_update with unsupported operator raises error."""
     update = {"$rename": {"name": "full_name"}}
-    with pytest.raises(KeyError):
+    with pytest.raises(UnsupportedMongoActionError):
         bio_coll._validate_mongo_update(update)
 
 
@@ -566,7 +566,7 @@ async def test_1251__find_one_field_dotted_key_raises(
     """Test find_one_field raises ValueError for dotted (nested) field paths."""
     bio_coll.find_one = AsyncMock()  # type: ignore[method-assign]  # ty:ignore[invalid-assignment]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(UnsupportedMongoActionError):
         await bio_coll.find_one_field({"name": "Alice"}, "address.city")
 
     # the wrapper should not be invoked at all when the input is malformed

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -111,7 +111,10 @@ class MongoJSONSchemaValidatedCollection:
         mongo_obj: MongoDoc,
         allow_partial_update: bool = False,
     ) -> None:
-        """Wrap `jsonschema.validate` with logic for mongo syntax."""
+        """Wrap `jsonschema.validate` with logic for mongo syntax.
+
+        Raises `jsonschema.exceptions.ValidationError` if data is invalid.
+        """
         try:
             json_obj, out_schema = _convert_mongo_to_jsonschema(
                 mongo_obj,
@@ -166,6 +169,7 @@ class MongoJSONSchemaValidatedCollection:
                 "$push",  # Ex -- $push: {names: hank, sports: baseball}
                 "$addToSet",  # Ex -- same as $push, but only if value is unique
                 # $pullAll -- see vanilla operators above
+                # $pop -- see special case below
             ]:
                 self._validate(
                     {
@@ -175,6 +179,12 @@ class MongoJSONSchemaValidatedCollection:
                     },
                     allow_partial_update=True,
                 )
+            #
+            # LET MONGO DO ITS OWN VALIDATION -- raise 'pymongo.errors.WriteError' if invalid
+            elif operator in [
+                "$pop",  #  operator value is -1 or 1 -- not an array element
+            ]:
+                pass
             # EXPLICITLY UNSUPPORTED OPERATORS
             elif operator in [
                 "$rename",  # renaming a field could require a schema change
@@ -188,8 +198,6 @@ class MongoJSONSchemaValidatedCollection:
             else:
                 # $currentDate
                 #   - operator value is true or false -- not a field value
-                # $pop
-                #   - operator value is -1 or 1 -- not an array element
                 # $
                 #   - validating would require changing the 'update' field name -- tricky
                 # $[]

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -377,8 +377,19 @@ class MongoJSONSchemaValidatedCollection:
         """Find all matching the aggregate pipeline.
 
         Yields nothing if no docs are found.
+
+        NOTE: Only read actions are supported in the aggregate pipeline --
+        "$out" and "$merge" are not allowed, as the data cannot be validated.
         """
         self.logger.debug(f"finding with aggregate pipeline: {pipeline}")
+
+        # check that no write stage is present in the pipeline
+        for stage in pipeline:
+            for k in stage:
+                if k in ["$out", "$merge"]:
+                    raise UnsupportedMongoActionError(
+                        f"Aggregate pipeline cannot write to a collection ('{k}')."
+                    )
 
         # PyMongo async's AsyncCollection.aggregate() returns a coroutine
         # that must be awaited to obtain the async cursor.
@@ -402,6 +413,8 @@ class MongoJSONSchemaValidatedCollection:
         """Find one matching the aggregate pipeline.
 
         Appends `{"$limit": 1}` to pipeline.
+
+        The same notes and caveats in `aggregate()` apply here.
 
         Raises `DocumentNotFoundException` if no doc is found.
         """

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -136,7 +136,10 @@ class MongoJSONSchemaValidatedCollection:
     def _validate_mongo_update(self, update: MongoDoc) -> None:
         """Validate the data for each given mongo-syntax update operator."""
         for operator in update:
+            # VANILLA / SCALAR OPERATORS
             if operator == "$set":
+                # this is the "vanilla" mongo update operator -- most common
+                # Example: "$set": {"foo": "bar", "bat": 123}
                 self._validate(
                     update[operator],
                     allow_partial_update=True,
@@ -149,9 +152,12 @@ class MongoJSONSchemaValidatedCollection:
                 )
             # ARRAY OPERATORS
             elif operator == "$push":
+                # Example: "$push": {"names": "hank"} -- where "names" in db doc is an array
                 self._validate(
-                    # validate each value as if it was the whole field's list -- other wise `str != [str]`
-                    {k: [v] for k, v in update[operator].items()},
+                    {
+                        k: [v]  # each goes in its own 1-array: "hank" -> ["hank"]
+                        for k, v in update[operator].items()
+                    },
                     allow_partial_update=True,
                 )
             # FUTURE: insert more operators here
@@ -278,9 +284,12 @@ class MongoJSONSchemaValidatedCollection:
     ) -> Any:
         """Find one doc matching the query, then return the *value* of `field`.
 
-        **WARNING**: Do not pass in dotted keys, this will raise a `ValueError`.
-        The logic to support this is very complex and would need to account for various
-        shapes of nested objects, including arrays and mixed types.
+        **WARNING**: Do not pass in dotted keys, this will raise a
+        `CurrentlyUnsupportedActionError`. The logic to support this is very
+        complex and would need to account for various shapes of nested objects,
+        including arrays and mixed types. In the case of array traversing, this
+        would need to settle whether to return the first element or the entire
+        list of elements -- plus whether to flatten that or not.
 
         Do not provide `projection` -- this method will override it with `{field: 1}`.
 

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -218,7 +218,7 @@ class MongoJSONSchemaValidatedCollection:
                 #   - just look this one up in the docs... it's wild
                 # $bit
                 #   - operator value is a bitmask -- not a field value
-                #   - if we wan this, validate against a placeholder value of 1 (?)
+                #   - if we want this, validate against a placeholder value of 1 (?)
                 raise UnsupportedMongoActionError(
                     f"Mongo-update operator '{operator}' is not supported."
                 )

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -142,15 +142,18 @@ class MongoJSONSchemaValidatedCollection:
             if operator in [
                 "$set",  # Ex -- $set: {foo: bar, bat: 123}
                 "$setOnInsert",  # Ex -- same as $set, but only if doc is new (upsert)
-                "$pullAll",  # Ex -- $pullAll: {scores: [0,5]} -- pulls all from array
             ]:
                 self._validate(update[operator], allow_partial_update=True)
             #
             # SCALAR OPERATORS
             #   *** A WARNING ON THE LIMITATIONS OF JSONSCHEMA INTEGRATION ***
-            #     If your schema uses minimum and/or maximum constraints, the
-            #     validator may deem your scalar operator value invalid.
-            #     For example: minimum=5 maximum=100 currentvalue=10 operatorvalue=2
+            #       If your schema uses minimum and/or maximum constraints:
+            #         - the update-operator is validated, this may be
+            #             out-of-range (false negative)
+            #         - the new resulting DB value may be out-of-range,
+            #             and will go unvalidated (written data not checked)
+            #       Recommendation: Do not use minimum/maximum for any
+            #         mutable document fields.
             elif operator in [
                 "$min",  # Ex -- $min: {lowScore: 112} (mongo updates if 112 < db value)
                 "$max",  # Ex -- $max: {highScore: 881} (mongo updates if 881 > db value)
@@ -159,17 +162,20 @@ class MongoJSONSchemaValidatedCollection:
             ]:
                 self._validate(update[operator], allow_partial_update=True)
             #
-            # ARRAY OPERATORS
+            # ADDITIVE ARRAY OPERATORS -- write new array entry to a doc
             #   *** A WARNING ON THE LIMITATIONS OF JSONSCHEMA INTEGRATION ***
-            #     If your schema uses minItems and/or maxItems constraints, the
-            #     validator may deem your operator value invalid.
-            #     For example: minItems=6 minItems=22 current_len=10 -- operator_len=1
+            #       If your schema uses minItems and/or maxItems array
+            #       constraints:
+            #         - the update-operator is validated (aka len=1),
+            #             this may be out-of-range (false negative)
+            #         - the new resulting DB value may be out-of-range,
+            #             and will go unvalidated (written data not checked)
+            #       Recommendation: Do not use minItems/maxItems for any
+            #         mutable document fields.
             elif operator in [
                 # Assume: the "names" field in the collection schema is an array -- "sports" too
                 "$push",  # Ex -- $push: {names: hank, sports: baseball}
                 "$addToSet",  # Ex -- same as $push, but only if value is unique
-                # $pullAll -- see vanilla operators above
-                # $pop -- see special case below
             ]:
                 self._validate(
                     {
@@ -180,11 +186,16 @@ class MongoJSONSchemaValidatedCollection:
                     allow_partial_update=True,
                 )
             #
-            # LET MONGO DO ITS OWN VALIDATION -- raise 'pymongo.errors.WriteError' if invalid
+            # SUBTRACTIVE ARRAY OPERATORS -- remove existing array entry(ies) from a doc
+            #   *** A WARNING ON THE LIMITATIONS OF JSONSCHEMA INTEGRATION ***
+            #       See the warning above for "ADDITIVE ARRAY OPERATORS"
             elif operator in [
-                "$pop",  #  operator value is -1 or 1 -- not an array element
+                "$pop",  # mongo will validate the update shape (-1 or 1)
+                "$pull",
+                "$pullAll",
             ]:
-                pass
+                pass  # let mongo raise 'pymongo.errors.WriteError' if invalid
+            #
             # EXPLICITLY UNSUPPORTED OPERATORS
             elif operator in [
                 "$rename",  # renaming a field could require a schema change
@@ -204,8 +215,6 @@ class MongoJSONSchemaValidatedCollection:
                 #   - same as $
                 # $[<identifier>]
                 #   - just look this one up in the docs... it's wild
-                # $pull
-                #   - operator value is a query -- not a field value
                 # $bit
                 #   - operator value is a bitmask -- not a field value
                 raise UnsupportedMongoActionError(

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -137,22 +137,19 @@ class MongoJSONSchemaValidatedCollection:
         """Validate the data for each given mongo-syntax update operator."""
         for operator in update:
             # VANILLA / SCALAR OPERATORS
-            if operator == "$set":
-                # this is the "vanilla" mongo update operator -- most common
-                # Example: "$set": {"foo": "bar", "bat": 123}
-                self._validate(
-                    update[operator],
-                    allow_partial_update=True,
-                )
-            elif operator == "$inc":
-                # Example: "$inc": {"next_attempt": 5, "i": 1}
+            if operator in [
+                "$set",  # Example: "$set": {"foo": "bar", "bat": 123} -- most common
+                "$inc",  # Example: "$inc": {"next_attempt": 5, "i": 1}
+            ]:
                 self._validate(
                     update[operator],
                     allow_partial_update=True,
                 )
             # ARRAY OPERATORS
-            elif operator == "$push":
-                # Example: "$push": {"names": "hank"} -- where "names" in db doc is an array
+            elif operator in [
+                # Assume: the "names" field in the collection schema is an array -- "sports" too
+                "$push",  # Example: "$push": {"names": "hank", "sports": "baseball"}
+            ]:
                 self._validate(
                     {
                         k: [v]  # each goes in its own 1-array: "hank" -> ["hank"]

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -27,6 +27,13 @@ JSON: TypeAlias = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | 
 MongoDoc: TypeAlias = dict[str, Any]  # mongo can carry ObjectId, datetime, Binary, etc
 
 
+class CurrentlyUnsupportedActionError(Exception):
+    """Raised when an action is not yet supported, but otherwise could be.
+
+    If you see this in the wild... think about implementing it :)
+    """
+
+
 class DocumentNotFoundException(Exception):
     """Raised when document is not found for a particular query."""
 
@@ -149,7 +156,9 @@ class MongoJSONSchemaValidatedCollection:
                 )
             # FUTURE: insert more operators here
             else:
-                raise KeyError(f"Unsupported mongo-syntax update operator: {operator}")
+                raise CurrentlyUnsupportedActionError(
+                    f"Unsupported mongo-update operator: {operator}"
+                )
 
     async def insert_one(
         self,
@@ -278,7 +287,9 @@ class MongoJSONSchemaValidatedCollection:
         Raises `DocumentNotFoundException` if no doc is found.
         """
         if "." in field:
-            raise ValueError("Dotted keys are not supported for this method.")
+            raise CurrentlyUnsupportedActionError(
+                "Dotted keys are not supported for find_one_field(), use find_one() instead."
+            )
 
         kwargs["projection"] = {field: 1}
         doc = await self.find_one(query, **kwargs)  # ~> DocumentNotFoundException

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -200,6 +200,9 @@ class MongoJSONSchemaValidatedCollection:
             elif operator in [
                 "$rename",  # renaming a field could require a schema change
                 "$unset",  # deleting a field could require a schema change
+                "$currentDate",
+                # ^^^^^^^^^^^ operator value is true or false -- not a field value, AND
+                #   this stores a BSON timestamp, which is not a JSON primitive
             ]:
                 raise UnsupportedMongoActionError(
                     f"Mongo-update operator '{operator}' is unsupported by design."
@@ -207,8 +210,6 @@ class MongoJSONSchemaValidatedCollection:
             #
             # FUTURE DEV
             else:
-                # $currentDate
-                #   - operator value is true or false -- not a field value
                 # $
                 #   - validating would require changing the 'update' field name -- tricky
                 # $[]
@@ -217,8 +218,9 @@ class MongoJSONSchemaValidatedCollection:
                 #   - just look this one up in the docs... it's wild
                 # $bit
                 #   - operator value is a bitmask -- not a field value
+                #   - if we wan this, validate against a placeholder value of 1 (?)
                 raise UnsupportedMongoActionError(
-                    f"Mongo-update operator '{operator}' is not (yet) supported."
+                    f"Mongo-update operator '{operator}' is not supported."
                 )
 
     async def insert_one(

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -138,8 +138,8 @@ class MongoJSONSchemaValidatedCollection:
         for operator in update:
             # VANILLA / SCALAR OPERATORS
             if operator in [
-                "$set",  # Example: "$set": {"foo": "bar", "bat": 123} -- most common
-                "$inc",  # Example: "$inc": {"next_attempt": 5, "i": 1}
+                "$set",  # Example: $set: {foo: bar, bat: 123} -- most common
+                "$inc",  # Example: $inc: {next_attempt: 5, i: 1}
             ]:
                 self._validate(
                     update[operator],
@@ -148,13 +148,13 @@ class MongoJSONSchemaValidatedCollection:
             # ARRAY OPERATORS
             elif operator in [
                 # Assume: the "names" field in the collection schema is an array -- "sports" too
-                "$push",  # Example: "$push": {"names": "hank", "sports": "baseball"}
+                "$push",  # Example: $push: {names: hank, sports: baseball}
             ]:
                 self._validate(
                     {
                         k: [v]
                         for k, v in update[operator].items()
-                        # Example: {"names": ["hank"], "sports": ["baseball"]}
+                        # Example: {names: [hank], sports: [baseball]}
                     },
                     allow_partial_update=True,
                 )

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -27,11 +27,8 @@ JSON: TypeAlias = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | 
 MongoDoc: TypeAlias = dict[str, Any]  # mongo can carry ObjectId, datetime, Binary, etc
 
 
-class CurrentlyUnsupportedActionError(Exception):
-    """Raised when an action is not yet supported, but otherwise could be.
-
-    If you see this in the wild... think about implementing it :)
-    """
+class UnsupportedMongoActionError(Exception):
+    """Raised when an action is not supported."""
 
 
 class DocumentNotFoundException(Exception):
@@ -135,20 +132,40 @@ class MongoJSONSchemaValidatedCollection:
 
     def _validate_mongo_update(self, update: MongoDoc) -> None:
         """Validate the data for each given mongo-syntax update operator."""
+        # See Documentation: https://www.mongodb.com/docs/manual/reference/mql/update/
         for operator in update:
-            # VANILLA / SCALAR OPERATORS
+            #
+            # VANILLA OPERATORS -- most common
             if operator in [
-                "$set",  # Example: $set: {foo: bar, bat: 123} -- most common
-                "$inc",  # Example: $inc: {next_attempt: 5, i: 1}
+                "$set",  # Ex -- $set: {foo: bar, bat: 123}
+                "$setOnInsert",  # Ex -- same as $set, but only if doc is new (upsert)
+                "$pullAll",  # Ex -- $pullAll: {scores: [0,5]} -- pulls all from array
             ]:
-                self._validate(
-                    update[operator],
-                    allow_partial_update=True,
-                )
+                self._validate(update[operator], allow_partial_update=True)
+            #
+            # SCALAR OPERATORS
+            #   *** A WARNING ON THE LIMITATIONS OF JSONSCHEMA INTEGRATION ***
+            #     If your schema uses minimum and/or maximum constraints, the
+            #     validator may deem your scalar operator value invalid.
+            #     For example: minimum=5 maximum=100 currentvalue=10 operatorvalue=2
+            elif operator in [
+                "$min",  # Ex -- $min: {lowScore: 112} (mongo updates if 112 < db value)
+                "$max",  # Ex -- $max: {highScore: 881} (mongo updates if 881 > db value)
+                "$inc",  # Ex -- $inc: {next_attempt: 5, i: 1}
+                "$mul",  # Ex -- $mul: {price: 2}
+            ]:
+                self._validate(update[operator], allow_partial_update=True)
+            #
             # ARRAY OPERATORS
+            #   *** A WARNING ON THE LIMITATIONS OF JSONSCHEMA INTEGRATION ***
+            #     If your schema uses minItems and/or maxItems constraints, the
+            #     validator may deem your operator value invalid.
+            #     For example: minItems=6 minItems=22 current_len=10 -- operator_len=1
             elif operator in [
                 # Assume: the "names" field in the collection schema is an array -- "sports" too
-                "$push",  # Example: $push: {names: hank, sports: baseball}
+                "$push",  # Ex -- $push: {names: hank, sports: baseball}
+                "$addToSet",  # Ex -- same as $push, but only if value is unique
+                # $pullAll -- see vanilla operators above
             ]:
                 self._validate(
                     {
@@ -158,10 +175,33 @@ class MongoJSONSchemaValidatedCollection:
                     },
                     allow_partial_update=True,
                 )
-            # FUTURE: insert more operators here
+            # EXPLICITLY UNSUPPORTED OPERATORS
+            elif operator in [
+                "$rename",  # renaming a field could require a schema change
+                "$unset",  # deleting a field could require a schema change
+            ]:
+                raise UnsupportedMongoActionError(
+                    f"Mongo-update operator '{operator}' is unsupported by design."
+                )
+            #
+            # FUTURE DEV
             else:
-                raise CurrentlyUnsupportedActionError(
-                    f"Unsupported mongo-update operator: {operator}"
+                # $currentDate
+                #   - operator value is true or false -- not a field value
+                # $pop
+                #   - operator value is -1 or 1 -- not an array element
+                # $
+                #   - validating would require changing the 'update' field name -- tricky
+                # $[]
+                #   - same as $
+                # $[<identifier>]
+                #   - just look this one up in the docs... it's wild
+                # $pull
+                #   - operator value is a query -- not a field value
+                # $bit
+                #   - operator value is a bitmask -- not a field value
+                raise UnsupportedMongoActionError(
+                    f"Mongo-update operator '{operator}' is not (yet) supported."
                 )
 
     async def insert_one(
@@ -294,7 +334,7 @@ class MongoJSONSchemaValidatedCollection:
         Raises `DocumentNotFoundException` if no doc is found.
         """
         if "." in field:
-            raise CurrentlyUnsupportedActionError(
+            raise UnsupportedMongoActionError(
                 "Dotted keys are not supported for find_one_field(), use find_one() instead."
             )
 

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -152,8 +152,9 @@ class MongoJSONSchemaValidatedCollection:
             ]:
                 self._validate(
                     {
-                        k: [v]  # each goes in its own 1-array: "hank" -> ["hank"]
+                        k: [v]
                         for k, v in update[operator].items()
+                        # Example: {"names": ["hank"], "sports": ["baseball"]}
                     },
                     allow_partial_update=True,
                 )

--- a/wipac_dev_tools/mongo_jsonschema_tools.py
+++ b/wipac_dev_tools/mongo_jsonschema_tools.py
@@ -134,6 +134,13 @@ class MongoJSONSchemaValidatedCollection:
                     update[operator],
                     allow_partial_update=True,
                 )
+            elif operator == "$inc":
+                # Example: "$inc": {"next_attempt": 5, "i": 1}
+                self._validate(
+                    update[operator],
+                    allow_partial_update=True,
+                )
+            # ARRAY OPERATORS
             elif operator == "$push":
                 self._validate(
                     # validate each value as if it was the whole field's list -- other wise `str != [str]`


### PR DESCRIPTION
Adds support for many more mongo update operators: `$setOnInsert`, `$min`, `$max`, `$inc`, `$mul`, `$addToSet`, `$pop`, `$pull`, and `$pullAll`. Previously, only `$set` and `$push` were supported.

This PR also adds integration tests with a MongoDB instance, and specific unit tests for the new operators.